### PR TITLE
fix(notebooks): Suppress ruff B018 and apply formatting

### DIFF
--- a/notebooks/nb01_data_loading.py
+++ b/notebooks/nb01_data_loading.py
@@ -85,7 +85,7 @@ def _(Path, mo):
         value=catalog_list[0]["name"],
         label="Test dataset (from Zenodo)",
     )
-    dataset_dropdown
+    dataset_dropdown  # noqa: B018
     return dataset_dropdown, test_data_path
 
 
@@ -206,7 +206,7 @@ def _(mo):
 
 @app.cell
 def _(Path, ds_info, folder_input, mo):
-    from aliby.io.dataset import DatasetZarr, dispatch_dataset
+    from aliby.io.dataset import DatasetZarr
 
     zarr_name = f"{ds_info['name']}.zarr"
     _folder = Path(folder_input.value)
@@ -281,7 +281,9 @@ def _(data, dims, mo, np):
     ncols = min(nch, 4)
     nrows = (nch + ncols - 1) // ncols
 
-    fig, axes = plt.subplots(nrows, ncols, figsize=(4 * ncols, 4 * nrows), squeeze=False)
+    fig, axes = plt.subplots(
+        nrows, ncols, figsize=(4 * ncols, 4 * nrows), squeeze=False
+    )
     for c in range(nch):
         ax = axes[c // ncols][c % ncols]
         # Max-project over Z for display

--- a/notebooks/nb02_cellpose_pipeline.py
+++ b/notebooks/nb02_cellpose_pipeline.py
@@ -42,8 +42,6 @@ def _():
 def _():
     from pathlib import Path
 
-    import numpy as np
-
     return (Path,)
 
 
@@ -71,7 +69,7 @@ def _(Path, mo):
         value=catalog[0]["name"],
         label="Test dataset (from Zenodo)",
     )
-    dataset_dropdown
+    dataset_dropdown  # noqa: B018
     return dataset_dropdown, test_data_path
 
 
@@ -269,7 +267,7 @@ def _(mo):
 @app.cell(hide_code=True)
 def _(mo):
     run_button = mo.ui.run_button(label="Run Pipeline")
-    run_button
+    run_button  # noqa: B018
     return (run_button,)
 
 
@@ -315,7 +313,9 @@ def _(mo):
 def _(mo, profiles):
     if profiles is not None and profiles.num_rows > 0:
         _df = profiles.to_pandas()
-        mo.output.replace(mo.ui.table(_df.head(50), label="Extracted profiles (first 50 rows)"))
+        mo.output.replace(
+            mo.ui.table(_df.head(50), label="Extracted profiles (first 50 rows)")
+        )
     else:
         mo.output.replace(mo.md("_No profile data to display._"))
     return

--- a/notebooks/nb03_deep_learning.py
+++ b/notebooks/nb03_deep_learning.py
@@ -47,8 +47,6 @@ def _():
 def _():
     from pathlib import Path
 
-    import numpy as np
-
     return (Path,)
 
 
@@ -76,7 +74,7 @@ def _(Path, mo):
         value=catalog[0]["name"],
         label="Test dataset (from Zenodo)",
     )
-    dataset_dropdown
+    dataset_dropdown  # noqa: B018
     return dataset_dropdown, test_data_path
 
 
@@ -216,7 +214,7 @@ def _(MODEL_REGISTRY, mo):
         value=MODEL_REGISTRY["openphenom"]["label"],
         label="Embedding model",
     )
-    model_selector
+    model_selector  # noqa: B018
     return (model_selector,)
 
 
@@ -229,7 +227,9 @@ def _(MODEL_REGISTRY, mo, model_selector):
         label="Nahual server address",
     )
     tile_size_input = mo.ui.slider(
-        start=128, stop=512, step=64,
+        start=128,
+        stop=512,
+        step=64,
         value=_model["default_tile_size"],
         label="Tile size",
     )
@@ -324,7 +324,11 @@ def _(
     tile_size = tile_size_input.value
 
     dl_pipeline = build_embed_pipeline(
-        input_path, address, tile_size, ds_info, model_config,
+        input_path,
+        address,
+        tile_size,
+        ds_info,
+        model_config,
     )
     embed_step = [s for s in dl_pipeline["steps"] if s.startswith("nahual_")][0]
 
@@ -415,7 +419,7 @@ def _(MODEL_REGISTRY, mo):
         _rows.append(
             f"| **{_m['label'].split(' (')[0]}** "
             f"| [{_m['server_repo']}](https://github.com/{_m['server_repo']}) "
-            f"| `\"{_m['model_group']}\"` "
+            f'| `"{_m["model_group"]}"` '
             f"| {_ch} "
             f"| {_m['default_tile_size']} "
             f"| `{_m['default_address']}` |"
@@ -424,9 +428,7 @@ def _(MODEL_REGISTRY, mo):
     mo.md(
         "## 6. All Embedding Models\n\n"
         "| Model | Server repo | model_group | Input channels | Tile size | Default IPC |\n"
-        "|---|---|---|---|---|---|\n"
-        + "\n".join(_rows)
-        + "\n\n"
+        "|---|---|---|---|---|---|\n" + "\n".join(_rows) + "\n\n"
         "All pipelines follow the same pattern:\n"
         "1. **Tile** the input image into crops of the configured size\n"
         "2. **Send pixel data** to the Nahual server via IPC\n"


### PR DESCRIPTION
## Summary
- Added `# noqa: B018` to 5 bare marimo widget expressions across 3 notebook files that were causing CI lint failures (ruff B018 "Found useless expression"). These are legitimate marimo patterns where the bare expression is the cell's rendered output.
- Applied `nix fmt` formatting fixes: removed unused imports (`numpy` in nb02, nb03; `dispatch_dataset` in nb01), reformatted long lines.

## Test plan
- [x] `nix fmt` passes with no changes
- [x] `ruff check notebooks/` passes (All checks passed)
