### PR TITLE
fix(segment): preprocess FCZYX pixels before nahual cellpose

### DIFF
--- a/src/aliby/segment/dispatch.py
+++ b/src/aliby/segment/dispatch.py
@@ -76,7 +76,19 @@ def dispatch_segmenter(
             info = setup(setup_params, address=address)
             print(f"Cellpose via nahual set up. Remote returned {info}")
 
-            return partial(process, address=address)
+            def nahual_segment(pixels: np.ndarray) -> np.ndarray:
+                """Preprocess FCZYX pixels before sending to nahual cellpose."""
+                if pixels.ndim > 5:
+                    pixels = pixels[0]
+                pixels = pixels[:, channel_to_segment]  # FCZYX -> FZYX
+                z_size = pixels.shape[1]
+                if z_size > 1:
+                    pixels = pixels.max(axis=1)  # FZYX -> FYX
+                else:
+                    pixels = pixels[:, 0]  # squeeze Z
+                return process(pixels, address=address)
+
+            return nahual_segment
         case "cellpose":  # One of the cellpose models
             # cellpose does without all the ABC stuff
             # It returns a function to segment


### PR DESCRIPTION
## Summary
- Wrap the nahual `process` call in `dispatch_segmenter` with a small adapter that reduces incoming `FCZYX` (or larger) pixel arrays to the 2D `FYX` shape the remote cellpose expects: drops the leading batch axis if present, selects `channel_to_segment`, and max-projects Z when there are multiple planes.

## Test plan
- [ ] Run a pipeline using the `nahual` cellpose backend against a multi-Z, multi-channel input and confirm segmentation labels are returned without dimension errors.
- [ ] Run with a single-Z input to confirm the squeeze branch still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)