### PR TITLE
perf(pipe): bound per-position memory in long-T runs

### DIFF
--- a/src/aliby/pipe.py
+++ b/src/aliby/pipe.py
@@ -348,15 +348,30 @@ def pipeline_step(
             )
 
         # Update state
-        # TODO replace this with a variable to adjust ntps in memory
         state["data"][step_name].append(step_result)
-        # We carry on all the states, as they are necessary for processing later
-        # state["data"][step_name] = state["data"][step_name][-5:]
 
         # Update or initialise objects
         if step_name not in state["fn"]:
             state["fn"][step_name] = step
         state["tps"][step_name] = tp + 1
+
+    # End-of-tp memory hygiene.
+    # 1. Drop the raw pixel block from the tile step's last entry. Tile pixels
+    #    are only consumed within this same tp by segment/extract via
+    #    passed_data; they are never re-read after the tp finishes.
+    for step_name in state["data"]:
+        if step_name.startswith("tile"):
+            entry = state["data"][step_name][-1] if state["data"][step_name] else None
+            if isinstance(entry, dict) and "pixels" in entry:
+                del entry["pixels"]
+
+    # 2. Trim per-step history per the pipeline's "retain" config.
+    #    retain[step_name] = int (keep last N) or "all" (default).
+    retain_cfg = pipeline.get("retain", {})
+    for step_name, history in state["data"].items():
+        keep = retain_cfg.get(step_name, "all")
+        if isinstance(keep, int) and keep >= 0 and len(history) > keep:
+            del history[: len(history) - keep]
 
     return state
 
@@ -431,6 +446,36 @@ def validate_pipeline(pipeline: dict) -> None:
         ):
             raise ValueError(
                 f"'save_interval' must be a positive int, got {save_interval!r}."
+            )
+
+    retain = pipeline.get("retain", {})
+    if not isinstance(retain, dict):
+        raise TypeError(
+            "'retain' must be a dictionary mapping step name to int or 'all'."
+        )
+    for step_name, keep in retain.items():
+        if step_name not in steps:
+            raise ValueError(
+                f"'retain' references step '{step_name}' not defined in 'steps'."
+            )
+        if keep != "all" and not (
+            isinstance(keep, int) and not isinstance(keep, bool) and keep >= 0
+        ):
+            raise ValueError(
+                f"'retain[{step_name}]' must be a non-negative int or 'all', got {keep!r}."
+            )
+        # Per-tp tracker reads last 2 segment outputs.
+        track_reads_segment = any(
+            from_step == step_name
+            for target, deps in passed_data.items()
+            if target.startswith("track")
+            for dep in deps
+            if (from_step := dep[1])
+        )
+        if track_reads_segment and isinstance(keep, int) and keep < 2:
+            raise ValueError(
+                f"'retain[{step_name}]' = {keep} is too small; per-tp 'track' step "
+                f"reads the last 2 timepoints of '{step_name}'."
             )
 
     for k, params in steps.items():
@@ -578,7 +623,9 @@ def run_pipeline_and_post(
                 step_fn = init_step(step_name, parameters)
 
                 input_data = get_step_output(
-                    state["data"], pipeline["global_passed_data"][output_name]
+                    state["data"],
+                    pipeline["global_passed_data"][output_name],
+                    steps_dir=steps_dir,
                 )
                 post_result = step_fn(input_data=input_data)
                 post_results[output_name] = post_result
@@ -672,18 +719,32 @@ def get_profiles_from_state(state: dict, pipeline: dict) -> pyarrow.Table:
     return profiles
 
 
-def get_step_output(state_data: dict, fetchers: tuple[Callable | str]) -> numpy.ndarray:
+def get_step_output(
+    state_data: dict,
+    fetchers: tuple[Callable | str],
+    steps_dir: Path | None = None,
+) -> numpy.ndarray:
     """Dynamic fetcher for other outputs. It aggregates data over time points.
 
-    fetchers: if a string, just fetch the entire output, if a function (callable) apply this to the output of every time point
-
-    Returns a
+    fetchers: each item may be
+        - a step-name string (read from in-memory state_data)
+        - "from_disk:<step_name>" (read per-tp .npz files from steps_dir/<step_name>)
+        - a callable applied to state_data
     """
     combined_outputs = []
     for fetcher in fetchers:
         if isinstance(fetcher, str):
-            # HACK: This is assuming a monotile, we should instead output always assuming tiles
-            aggregated_output = [x[0] for x in state_data[fetcher]]
+            if fetcher.startswith("from_disk:"):
+                if steps_dir is None:
+                    raise ValueError(
+                        "from_disk fetcher requires steps_dir; pass it through "
+                        "get_step_output(..., steps_dir=...)"
+                    )
+                step_name = fetcher.removeprefix("from_disk:")
+                aggregated_output = _load_per_tp_masks(Path(steps_dir) / step_name)
+            else:
+                # HACK: This is assuming a monotile, we should instead output always assuming tiles
+                aggregated_output = [x[0] for x in state_data[fetcher]]
         elif isinstance(fetcher, Callable):
             aggregated_output = fetcher(state_data)
         else:
@@ -693,3 +754,35 @@ def get_step_output(state_data: dict, fetchers: tuple[Callable | str]) -> numpy.
         combined_outputs.append(aggregated_output)
 
     return numpy.asarray(combined_outputs)
+
+
+def _load_per_tp_masks(step_dir: Path) -> list[numpy.ndarray]:
+    """Read per-tp .npz mask files written by io.write.write_ndarray.
+
+    Mirrors the in-memory monotile slice ``[x[0] for x in state_data[step]]``
+    so trackastra (and any other consumer of get_step_output) sees identical
+    shapes whether masks come from RAM or disk.
+
+    Two on-disk formats are supported (see io/write.py:write_ndarray):
+      - baby segmenters: keys ``tile_0``, ``tile_1``, ... (one per tile)
+      - other segmenters: a single key ``arr_0`` holding a stacked
+        (tiles, Y, X) array
+    """
+    files = sorted(step_dir.glob("*.npz"))
+    if not files:
+        raise FileNotFoundError(
+            f"No per-tp .npz files found under {step_dir}; ensure this step "
+            f"is listed in pipeline['save']."
+        )
+    masks = []
+    for f in files:
+        with numpy.load(f) as npz:
+            keys = list(npz.keys())
+            if "tile_0" in keys:
+                masks.append(npz["tile_0"])
+            elif keys == ["arr_0"]:
+                stacked = npz["arr_0"]
+                masks.append(stacked[0])
+            else:
+                raise ValueError(f"Unrecognised .npz layout in {f}: keys={keys}")
+    return masks

--- a/src/aliby/pipe_builder.py
+++ b/src/aliby/pipe_builder.py
@@ -56,6 +56,8 @@ def build_pipeline_steps(
     segmenter_kind: str | None = None,
     baby_modelset: str | None = None,
     baby_address: str | None = None,
+    trackastra_address: str | None = None,
+    trackastra_parameters: dict | None = None,
 ) -> dict:
     """
     Convenience function to build a pipeline definition, does not fill in IO.
@@ -212,6 +214,34 @@ def build_pipeline_steps(
 
     if steps_to_write is not None:
         base_pipeline["save"] = list(steps_to_write)
+
+    if trackastra_address is not None:
+        # Disk-backed trackastra: per-tp segment masks are saved by the main
+        # loop, then nahual_trackastra reads them back via the "from_disk:"
+        # fetcher. This keeps state["data"]["segment_*"] bounded by retain=2
+        # (per-tp tracker still needs the last 2 timepoints in RAM) instead
+        # of growing with T.
+        seg_step_names = [f"segment_{obj}" for obj in channels_to_segment]
+        for seg in seg_step_names:
+            if seg not in base_pipeline["save"]:
+                base_pipeline["save"].append(seg)
+        base_pipeline["save"].append("nahual_trackastra")
+
+        base_pipeline["global_steps"] = {
+            "nahual_trackastra": dict(
+                address=trackastra_address,
+                parameters=trackastra_parameters or {},
+            ),
+        }
+        base_pipeline["global_passed_data"] = {
+            f"nahual_trackastra_{obj}": (f"from_disk:segment_{obj}",)
+            for obj in channels_to_segment
+        }
+
+        retain = base_pipeline.setdefault("retain", {})
+        for seg in seg_step_names:
+            retain.setdefault(seg, 2)
+        retain.setdefault("tile", 1)
 
     return base_pipeline
 

--- a/src/aliby/segment/dispatch.py
+++ b/src/aliby/segment/dispatch.py
@@ -11,6 +11,14 @@ import numpy as np
 from skimage.segmentation import relabel_sequential
 
 
+def _to_uint16_labels(labels: np.ndarray) -> np.ndarray:
+    if labels.size and labels.max() >= np.iinfo(np.uint16).max:
+        raise OverflowError(
+            f"Segmentation produced {labels.max()} labels; uint16 cast unsafe."
+        )
+    return labels.astype(np.uint16, copy=False)
+
+
 def dispatch_segmenter(
     kind: str, channel_to_segment: int, address: str = None, **kwargs
 ) -> callable:
@@ -51,12 +59,21 @@ def dispatch_segmenter(
                 # Return as list so process_tree_masks sees a per-tile structure.
                 tile_shape = pixels.shape[-2:]  # (Y, X) from input
                 per_tile = _process(pixels)
-                return [
+                projected = [
                     nyx.max(axis=0)
                     if nyx.shape[0] > 0
-                    else np.zeros(tile_shape, dtype=int)
+                    else np.zeros(tile_shape, dtype=np.uint16)
                     for nyx in per_tile
                 ]
+                for tile_labels in projected:
+                    if (
+                        tile_labels.size
+                        and tile_labels.max() >= np.iinfo(np.uint16).max
+                    ):
+                        raise OverflowError(
+                            f"Baby produced {tile_labels.max()} labels; uint16 cast unsafe."
+                        )
+                return [t.astype(np.uint16, copy=False) for t in projected]
 
             return segment
         case "nahual_cellpose":
@@ -76,7 +93,15 @@ def dispatch_segmenter(
             info = setup(setup_params, address=address)
             print(f"Cellpose via nahual set up. Remote returned {info}")
 
-            return partial(process, address=address)
+            remote = partial(process, address=address)
+
+            def segment(*args, **kwargs):
+                result = remote(*args, **kwargs)
+                if isinstance(result, list):
+                    return [_to_uint16_labels(r) for r in result]
+                return _to_uint16_labels(result)
+
+            return segment
         case "cellpose":  # One of the cellpose models
             # cellpose does without all the ABC stuff
             # It returns a function to segment
@@ -149,7 +174,11 @@ def dispatch_segmenter(
                         f"Segmentation yielded {result.ndim} dimensions instead of 3"
                     )
 
-                return labels
+                if labels.max() >= np.iinfo(np.uint16).max:
+                    raise OverflowError(
+                        f"Segmentation produced {labels.max()} labels; uint16 cast unsafe."
+                    )
+                return labels.astype(np.uint16, copy=False)
 
         case _:
             raise Exception(f"Invalid segmentation method {kind}")


### PR DESCRIPTION
## Summary
- Drop tile pixels from `state["data"]` at end-of-tp and add a per-step `retain` config (`int` = keep last N, `"all"` = default) so segment/extract history no longer grows linearly with T. `validate_pipeline` rejects `retain[segment_*] < 2` when a per-tp `track` step is wired up.
- Add a `"from_disk:<step>"` fetcher to `get_step_output` (handles baby's `tile_*` keys and the stacked `arr_0` layout) and wire it through `run_pipeline_and_post`, so global trackers like `nahual_trackastra` stream per-tp masks back from disk instead of holding T frames in RAM.
- `build_pipeline_steps` now accepts a `trackastra_address` (+ optional parameters), auto-adds the relevant `segment_*` steps to `save`, and seeds `retain` defaults.
- Cast cellpose / nahual_cellpose / nahual_baby segmentation outputs to `uint16` with an explicit overflow guard.

## Test plan
- [ ] Run a long-T position end-to-end with the new `retain` defaults and confirm RSS stays roughly flat across timepoints.
- [ ] Run the same pipeline with a `nahual_trackastra` global step using `from_disk:segment_*` and verify it matches the in-memory tracker output.
- [ ] Trip the validation guard: `retain[segment_cells] = 1` with a per-tp `track` step should raise.
- [ ] Run a baby-segmenter pipeline and a cellpose pipeline; confirm uint16 cast applies and overflow guard fires on a synthetic >65k-label input.
