### PR TITLE
refactor(pipe): Split pipeline into core and specialized modules

### DIFF
--- a/src/aliby/pipe.py
+++ b/src/aliby/pipe.py
@@ -19,14 +19,6 @@ from aliby.pipe_core import (
     _init_nahual_track,
     _init_tile,
     _run_pipeline_and_post_impl,
-    configure_logging,
-    get_profiles_from_state,
-    get_step_output,
-    pipeline_step,
-    run_pipeline_return_state,
-    run_step,
-    slice_channels_process,
-    validate_pipeline,
 )
 from aliby.segment.dispatch import dispatch_segmenter
 from aliby.track.dispatch import dispatch_tracker
@@ -83,17 +75,3 @@ def init_step(
 run_pipeline_and_post = partial(
     _run_pipeline_and_post_impl, init_step_fn=init_step, post_state_hook=None
 )
-
-
-__all__ = [
-    "configure_logging",
-    "get_profiles_from_state",
-    "get_step_output",
-    "init_step",
-    "pipeline_step",
-    "run_pipeline_and_post",
-    "run_pipeline_return_state",
-    "run_step",
-    "slice_channels_process",
-    "validate_pipeline",
-]

--- a/src/aliby/pipe.py
+++ b/src/aliby/pipe.py
@@ -1,788 +1,99 @@
 #!/usr/bin/env jupyter
 """
-New and simpler pipeline that uses dictionaries as parameters and to define variable and between-step method execution.
+Cellpose + cp_measure pipeline (the standard).
+
+Segments with Cellpose (local or remote via Nahual) and extracts features with
+cp_measure. Also supports Nahual embedders and optional Nahual trackastra.
+
+For BABY (overlapping masks, BABY-specific tracking/lineage), see
+``aliby.pipe_baby``.
 """
 
 from functools import partial
-from itertools import cycle
-from pathlib import Path
 from typing import Callable
 
-import numcodecs
-import numpy
-import pyarrow
-import pyarrow as pa
-from imagecodecs.numcodecs import Jpegxl
-from loguru import logger
-
-
-from aliby.global_steps import dispatch_global_step
-from aliby.io.image import dispatch_image
-from aliby.io.write import dispatch_write_fn
-from aliby.segment.dispatch import dispatch_segmenter
-from aliby.tile.tiler import dispatch_tiler
-from aliby.track.dispatch import dispatch_tracker
-from extraction.extract import (
-    extract_tree,
-    extract_tree_multi,
-    format_extraction,
-    process_tree_masks,
-    process_tree_masks_overlap,
+from aliby.pipe_core import (
+    _init_extract,
+    _init_extract_multi,
+    _init_nahual_embed,
+    _init_nahual_track,
+    _init_tile,
+    _run_pipeline_and_post_impl,
+    configure_logging,
+    get_profiles_from_state,
+    get_step_output,
+    pipeline_step,
+    run_pipeline_return_state,
+    run_step,
+    slice_channels_process,
+    validate_pipeline,
 )
-
-numcodecs.register_codec(Jpegxl)
-
-# from aliby.tile.tiler import Tiler, TilerParameters,
+from aliby.segment.dispatch import dispatch_segmenter
+from aliby.track.dispatch import dispatch_tracker
 
 
-def configure_logging(file):
-    # Remove default standard library logging handler
-    logger.remove()
-
-    # Configure file logging with rotation and compression
-    logger.add(
-        file,
-        rotation="10 MB",
-        retention="1 week",
-        compression="zip",
-        level="DEBUG",
-        format="{time:YYYY-MM-DD HH:mm:ss.SSS} | {level: <8} | {name}:{function}:{line} - {message}",
+def _init_segment_cellpose(
+    step_name: str, parameters: dict, other_steps: dict
+) -> Callable:
+    seg_kwargs = parameters.get("segmenter_kwargs", {})
+    if "channel_to_segment" not in parameters:
+        raise ValueError(
+            f"Step '{step_name}' is missing required 'channel_to_segment'."
+        )
+    return dispatch_segmenter(
+        channel_to_segment=parameters["channel_to_segment"],
+        **seg_kwargs,
     )
+
+
+def _init_track_cellpose(
+    step_name: str, parameters: dict, other_steps: dict
+) -> Callable:
+    return dispatch_tracker(**parameters)
 
 
 def init_step(
     step_name: str,
-    parameters: dict[str, str or callable or int or dict],
-    other_steps: dict = None,
-) -> callable:
-    """
-    Set up the parameters for any step. This mostly includes dispatching a specific step subtype.
-
-    If we need to perform some validation before commiting to a pipeline (e.g., checking the
-    servers for a nahual process), this is the place to do it.
-    """
+    parameters: dict,
+    other_steps: dict | None = None,
+) -> Callable:
+    """Set up parameters for any step in the cellpose pipeline."""
     if other_steps is None:
         other_steps = {}
 
     match step_name:
         case s if s.startswith("tile"):
-            image_kwargs = parameters.pop("image_kwargs", None)
-            if image_kwargs is None:
-                raise ValueError(
-                    f"Step '{step_name}' is missing required 'image_kwargs'."
-                )
-            if "source" not in image_kwargs:
-                raise ValueError(
-                    f"Step '{step_name}' 'image_kwargs' is missing required 'source'."
-                )
-            tiler_constructor = dispatch_tiler(parameters.pop("kind", None), parameters)
-            image_type = dispatch_image(source=image_kwargs["source"])
-            image = image_type(**image_kwargs)
-            step = tiler_constructor(image)
+            return _init_tile(s, parameters)
         case s if s.startswith("segment"):
-            seg_kwargs = parameters.get("segmenter_kwargs", {})
-            if seg_kwargs.get("kind", "").endswith("baby"):  # Baby needs a tiler inside
-                tiler_step = next(
-                    (v for k, v in other_steps.items() if k.startswith("tile")), None
-                )
-                if tiler_step is None:
-                    raise ValueError(
-                        f"Step '{step_name}' using 'baby' requires a preceding 'tile' step."
-                    )
-                seg_kwargs["tiler"] = tiler_step
-            if "channel_to_segment" not in parameters:
-                raise ValueError(
-                    f"Step '{step_name}' is missing required 'channel_to_segment'."
-                )
-            step = dispatch_segmenter(
-                channel_to_segment=parameters["channel_to_segment"],
-                **seg_kwargs,
-            )
+            return _init_segment_cellpose(s, parameters, other_steps)
         case s if s.startswith("track"):
-            if parameters.get("kind", "").endswith(
-                "baby"
-            ):  # tracker needs to pull info from baby crawler
-                segment_step = next(
-                    (v for k, v in other_steps.items() if k.startswith("segment")), None
-                )
-                if segment_step is None:
-                    raise ValueError(
-                        f"Step '{step_name}' using 'baby' tracking requires a preceding 'segment' step."
-                    )
-                parameters["crawler"] = segment_step.crawler
-            step = dispatch_tracker(**parameters)
+            return _init_track_cellpose(s, parameters, other_steps)
         case s if s.startswith("extract_"):
-            if "tree" not in parameters:
-                raise ValueError(f"Step '{step_name}' is missing required 'tree'.")
-            # Whether to use overlapping masks or not
-            process = process_tree_masks
-            measure_fn = extract_tree
-            if parameters.get("overlap"):
-                process = process_tree_masks_overlap
-                measure_fn = partial(extract_tree, overlap=True)
-            step = partial(
-                process,
-                measure_fn=measure_fn,
-                tree=parameters["tree"],
-                **parameters.get("kwargs", {}),
-            )
+            return _init_extract(s, parameters, overlap=False)
         case s if s.startswith("extractmulti_"):
-            if "tree" not in parameters:
-                raise ValueError(f"Step '{step_name}' is missing required 'tree'.")
-            step = partial(
-                process_tree_masks,
-                measure_fn=extract_tree_multi,
-                tree=parameters["tree"],
-                **parameters.get("kwargs", {}),
-            )
-            # Nahual steps (running server in a different process)
-        case s if s.startswith("nahual"):
-            # Validate that we can contact the server-side
-            # Setup also helps check that the remote server exists
-            address = parameters.get("address")
-            if address is None:
-                raise ValueError(
-                    f"If using Nahual you must have an address, currently it is None in step '{step_name}'"
-                )
-
-            if step_name.startswith("nahual_embed"):
-                if "setup_params" not in parameters:
-                    raise ValueError(
-                        f"Nahual embed step '{step_name}' is missing 'setup_params'."
-                    )
-                if "model_group" not in parameters:
-                    raise ValueError(
-                        f"Nahual embed step '{step_name}' is missing 'model_group'."
-                    )
-
-                from nahual.process import dispatch_setup_process
-
-                setup_params = parameters["setup_params"]
-                model_group = parameters["model_group"]
-
-                setup, process = dispatch_setup_process(model_group)
-
-                # If channel_ids exist subindex the input array
-                selected_channels = parameters.get("selected_channels")
-                if selected_channels:
-                    process = partial(
-                        slice_channels_process,
-                        process=process,
-                        selected_channels=selected_channels,
-                    )
-
-                info = setup(
-                    setup_params,
-                    address=address,
-                )
-                print(f"Embedder via nahual set up. Remote returned {info}")
-
-                return partial(process, address=address)
-            if step_name.startswith("nahual_track"):
-                if "parameters" not in parameters:
-                    raise ValueError(
-                        f"Nahual track step '{step_name}' is missing 'parameters'."
-                    )
-                setup, process = dispatch_global_step(step_name)
-                # print(f"NAHUAL: Setting up remote process on {parameters['address']}.")
-                setup_output = setup(parameters["parameters"], address=address)
-                print(f"NAHUAL: Remote process set up, returned {setup_output}.")
-
-                # For the final step we provide the address used for setting the remote up
-                step = partial(process, address=address)
+            return _init_extract_multi(s, parameters)
+        case s if s.startswith("nahual_embed"):
+            return _init_nahual_embed(s, parameters)
+        case s if s.startswith("nahual_track"):
+            return _init_nahual_track(s, parameters)
         case _:
             raise ValueError(f"Invalid step name {step_name=}")
 
-    return step
 
-
-def slice_channels_process(
-    data: numpy.ndarray,
-    process: Callable,
-    selected_channels: list[int] | numpy.ndarray,
-    **kwargs,
-) -> numpy.ndarray:
-    """
-    Apply a processing function to a subset of channels in a NumPy array.
-
-    Parameters
-    ----------
-    data : numpy.ndarray
-        The input array, expected to be at least 2D where the second
-        dimension represents channels.
-    process : callable
-        A function to be applied to the sliced data. It should accept the
-        sliced array as its first argument.
-    selected_channels : list of int or numpy.ndarray
-        Indices of the channels to select from the input data.
-    **kwargs : dict, optional
-        Additional keyword arguments to be passed to the `process` function.
-
-    Returns
-    -------
-    any
-        The result of the `process` function applied to the selected data.
-    """
-    return process(data[:, selected_channels], **kwargs)
-
-
-def run_step(step, *args, **kwargs):
-    if hasattr(step, "run_tp"):  # in case of older OO-style
-        result = step.run_tp(*args, **kwargs)
-    else:  # Functional version, all relevant kwargs are provided but no more
-        if "tp" in kwargs:
-            del kwargs["tp"]
-        result = step(*args, **kwargs)
-
-    return result
-
-
-def pipeline_step(
-    pipeline: dict,
-    state: dict = None,
-    steps_dir: str = None,
-) -> dict:
-    """Run one step of the pipeline."""
-    if state is None:
-        state = {}
-
-    steps = pipeline["steps"]
-    passed_data = pipeline["passed_data"]
-    passed_methods = pipeline.get("passed_methods", {})
-
-    if not state:  # Fresh state: initialise per-step counters and stores
-        state = {"tps": dict(zip(steps, cycle([0]))), "data": {}, "fn": {}}
-    tp = next(iter(state["tps"].values()))
-
-    for step_name, parameters in steps.items():
-        # Get or initialise step
-        if step_name not in state["data"]:
-            state["data"][step_name] = []
-        if step_name not in state["fn"]:
-            state["fn"][step_name] = init_step(step_name, parameters, state["fn"])
-        step = state["fn"][step_name]
-
-        # Pass input data if available
-        this_step_receives = pipeline["passed_data"].get(step_name, {})
-
-        # Specifies method calls between steps to get data.
-        # Format: {consumer_step: (producer_step, method_name, parameter_key)}
-        # parameter_key is pulled from the "parameters" subdict
-        passed_data = {}
-        for kwd, from_step, *varname in this_step_receives:
-            passed_value = state["data"].get(from_step, [])
-
-            step_argname = kwd
-            if len(varname):  # Use a different variable name to match the step
-                step_argname = varname[0]
-
-            if len(passed_value):
-                if (
-                    step_name == "track" and kwd == "masks"
-                ):  # Only tracking  masks require multiple time points
-                    # Convert tp,tile,y,x -> tile,tp,y,x for stitch tracking
-                    passed_data[step_argname] = [
-                        [tp_tiles[tile] for tp_tiles in passed_value[-2:]]
-                        for tile in range(len(passed_value[-1]))
-                    ]
-                else:  # We only care about the last time point
-                    last_value = passed_value[-1]
-                    if isinstance(last_value, dict):  # Select a subfield of the data
-                        last_value = last_value[kwd]
-                    passed_data[step_argname] = last_value
-
-                    # passed_data[kwd] = passed_value
-
-        # Run step
-
-        # HACK Adjust some edge cases to match BABY & Cellpose segmentation and downstream
-        # args = []
-        # if step_name.startswith("segment") or (
-        #     step_name.startswith("extract")
-        #     and any(x for x in steps if x.endswith("baby"))
-        # ):
-        #     # Pass correct images from tiler, except for "baby" which does everything by itself
-        #     segment_kind = parameters["segmenter_kwargs"]["kind"]
-        #     # if segment_kind != "nahual_baby":
-        #     source_step, method, param_name = passed_methods.get(step_name)
-
-        #     # Use tiler to pull data
-        #     args = getattr(state["fn"][source_step], method)(tp, parameters[param_name])
-        #     if segment_kind.endswith(
-        #         "baby"
-        #     ):  # We will expand the args so this is necessary TODO Homogenize
-        #         args = (args,)
-
-        # if step_name.startswith("extract") and any(x for x in steps if "baby" in x):
-        #     # source_step, method, param_name = passed_methods.get(step_name)
-        #     # args = getattr(state["fn"][source_step], method)(tp, parameters[param_name])
-        #     passed_data["pixels"] = args
-        #     args = []
-
-        args = []
-        if (
-            step_name.startswith("segment")
-            and parameters["segmenter_kwargs"]["kind"] != "baby"
-        ):  # Pass correct images from tiler
-            source_step, method = passed_methods.get(step_name)
-            args = (
-                getattr(state["fn"][source_step], method)(tp),
-            )  # This assumes that the source step is an object that contains the data
-
-        step_result = run_step(step, *args, tp=tp, **passed_data)
-
-        # Save state
-        steps_to_write = pipeline.get("save") or []
-        save_interval = pipeline.get("save_interval", 1)
-        should_save = (
-            bool(steps_to_write) and save_interval > 0 and (tp % save_interval) == 0
-        )
-        if should_save and step_name in steps_to_write:
-            print(f"Saving {step_name} to {steps_dir}")
-            write_fn = dispatch_write_fn(step_name)
-            write_fn(
-                step_result,
-                steps_dir=steps_dir,
-                subpath=step_name,
-                tp=tp,
-            )
-
-        # Update state
-        state["data"][step_name].append(step_result)
-
-        # Update or initialise objects
-        if step_name not in state["fn"]:
-            state["fn"][step_name] = step
-        state["tps"][step_name] = tp + 1
-
-    # End-of-tp memory hygiene.
-    # 1. Drop the raw pixel block from the tile step's last entry. Tile pixels
-    #    are only consumed within this same tp by segment/extract via
-    #    passed_data; they are never re-read after the tp finishes.
-    for step_name in state["data"]:
-        if step_name.startswith("tile"):
-            entry = state["data"][step_name][-1] if state["data"][step_name] else None
-            if isinstance(entry, dict) and "pixels" in entry:
-                del entry["pixels"]
-
-    # 2. Trim per-step history per the pipeline's "retain" config.
-    #    retain[step_name] = int (keep last N) or "all" (default).
-    retain_cfg = pipeline.get("retain", {})
-    for step_name, history in state["data"].items():
-        keep = retain_cfg.get(step_name, "all")
-        if isinstance(keep, int) and keep >= 0 and len(history) > keep:
-            del history[: len(history) - keep]
-
-    return state
-
-
-def validate_pipeline(pipeline: dict) -> None:
-    """
-    Sanity checks before computationally expensive operations.
-    Validates pipeline structure, dependencies, and parameters.
-    """
-    if not isinstance(pipeline, dict):
-        raise TypeError("Pipeline configuration must be a dictionary.")
-
-    if "steps" not in pipeline or not isinstance(pipeline["steps"], dict):
-        raise ValueError(
-            "Pipeline must contain a 'steps' dictionary mapping step names to parameters."
-        )
-
-    steps = pipeline["steps"]
-
-    # Validate passed_data existence since pipeline_step accesses it directly
-    if "passed_data" not in pipeline or not isinstance(pipeline["passed_data"], dict):
-        raise ValueError("Pipeline must contain a 'passed_data' dictionary.")
-
-    passed_data = pipeline["passed_data"]
-    for target_step, dependencies in passed_data.items():
-        if not isinstance(dependencies, (list, tuple)):
-            raise TypeError(
-                f"'passed_data' dependencies for step '{target_step}' must be a sequence."
-            )
-        for dep in dependencies:
-            if not isinstance(dep, (list, tuple)) or len(dep) < 2:
-                raise ValueError(
-                    f"Invalid dependency format in 'passed_data' for '{target_step}': {dep}"
-                )
-            from_step = dep[1]
-            if from_step not in steps:
-                raise ValueError(
-                    f"Step '{target_step}' expects data from '{from_step}', but '{from_step}' is not defined in 'steps'."
-                )
-
-    # Validate passed_methods
-    passed_methods = pipeline.get("passed_methods", {})
-    if not isinstance(passed_methods, dict):
-        raise TypeError("'passed_methods' must be a dictionary.")
-    for target_step, method_dep in passed_methods.items():
-        if not isinstance(method_dep, (list, tuple)) or len(method_dep) < 2:
-            raise ValueError(
-                f"Invalid method dependency format for '{target_step}': {method_dep}"
-            )
-        from_step = method_dep[0]
-        if from_step not in steps:
-            raise ValueError(
-                f"Step '{target_step}' expects a method from '{from_step}', but '{from_step}' is not defined in 'steps'."
-            )
-
-    steps_to_write = pipeline.get("save")
-    if steps_to_write is not None:
-        if not isinstance(steps_to_write, (list, tuple, set)):
-            raise TypeError("'save' must be a sequence of step names.")
-        for step in steps_to_write:
-            if step not in steps and step not in pipeline.get("global_steps", {}):
-                raise ValueError(
-                    f"Step '{step}' listed in 'save' is not defined in the pipeline 'steps' or 'global_steps'."
-                )
-
-    if "save_interval" in pipeline:
-        save_interval = pipeline["save_interval"]
-        if (
-            not isinstance(save_interval, int)
-            or isinstance(save_interval, bool)
-            or save_interval < 1
-        ):
-            raise ValueError(
-                f"'save_interval' must be a positive int, got {save_interval!r}."
-            )
-
-    retain = pipeline.get("retain", {})
-    if not isinstance(retain, dict):
-        raise TypeError(
-            "'retain' must be a dictionary mapping step name to int or 'all'."
-        )
-    for step_name, keep in retain.items():
-        if step_name not in steps:
-            raise ValueError(
-                f"'retain' references step '{step_name}' not defined in 'steps'."
-            )
-        if keep != "all" and not (
-            isinstance(keep, int) and not isinstance(keep, bool) and keep >= 0
-        ):
-            raise ValueError(
-                f"'retain[{step_name}]' must be a non-negative int or 'all', got {keep!r}."
-            )
-        # Per-tp tracker reads last 2 segment outputs.
-        track_reads_segment = any(
-            from_step == step_name
-            for target, deps in passed_data.items()
-            if target.startswith("track")
-            for dep in deps
-            if (from_step := dep[1])
-        )
-        if track_reads_segment and isinstance(keep, int) and keep < 2:
-            raise ValueError(
-                f"'retain[{step_name}]' = {keep} is too small; per-tp 'track' step "
-                f"reads the last 2 timepoints of '{step_name}'."
-            )
-
-    for k, params in steps.items():
-        if not isinstance(params, dict):
-            raise TypeError(f"Parameters for step '{k}' must be a dictionary.")
-        if k.startswith("nahual"):
-            if "address" not in params:
-                raise ValueError(
-                    f"Nahual-deployed step '{k}' must provide an 'address' parameter."
-                )
-
-    # Validate global_steps structure if present
-    global_steps = pipeline.get("global_steps", {})
-    if global_steps:
-        if "global_passed_data" not in pipeline:
-            raise ValueError(
-                "Pipeline defines 'global_steps' but is missing 'global_passed_data'."
-            )
-        if not isinstance(pipeline["global_passed_data"], dict):
-            raise TypeError("'global_passed_data' must be a dictionary.")
-
-
-def run_pipeline_return_state(pipeline: dict, steps_dir: str = None) -> dict:
-    validate_pipeline(pipeline)
-
-    state = {}
-
-    # TODO Add dimensionality to autodefine max_ntps
-    # TODO add assertion of ntps <= max_ntps
-    ntps = pipeline.get("ntps", 1)  # {"ntps": 1})["ntps"]
-    for _ in range(ntps):
-        # print(f"Processing frame {frame}")
-        state = pipeline_step(pipeline, state, steps_dir=steps_dir)
-        # print(f"Finished frame {frame}")
-
-    return state
-
-
-def _save_baby_tracking_lineage(
-    state: dict, pipeline: dict, output_path: Path, pipeline_name: str
-) -> None:
-    """Extract and save tracking/lineage from baby segment results.
-
-    Only does something when a segment step used nahual_baby and returned
-    dict results with 'metadata' keys.
-    """
-    for step_name in pipeline["steps"]:
-        if not step_name.startswith("segment"):
-            continue
-        seg_kwargs = pipeline["steps"][step_name].get("segmenter_kwargs", {})
-        if not seg_kwargs.get("kind", "").endswith("baby"):
-            continue
-
-        # Collect baby metadata across timepoints
-        step_data = state["data"].get(step_name, [])
-        baby_meta_history = []
-        for tp_result in step_data:
-            if isinstance(tp_result, dict) and "metadata" in tp_result:
-                baby_meta_history.append(tp_result["metadata"])
-
-        if not baby_meta_history:
-            continue
-
-        from aliby.segment.baby_parser import (
-            accumulate_lineage,
-            accumulate_tracking,
-            baby_tracking_to_table,
-        )
-
-        tracking = accumulate_tracking(baby_meta_history)
-        lineage = accumulate_lineage(baby_meta_history)
-        table = baby_tracking_to_table(tracking, lineage)
-
-        if len(table):
-            tracking_dir = output_path / "tracking"
-            tracking_dir.mkdir(parents=True, exist_ok=True)
-            out_file = tracking_dir / f"{pipeline_name}_{step_name}.parquet"
-            pyarrow.parquet.write_table(table, out_file, compression="zstd")
-            logger.info(f"Saved baby tracking/lineage to {out_file}")
-
-
-def run_pipeline_and_post(
-    pipeline: dict,
-    pipeline_name: str,
-    output_path: str | Path,
-    overwrite: bool = True,
-    # img_source: str | Path | list[str],
-    # logger=None,
-) -> tuple[pyarrow.Table, pyarrow.Table]:
-    """
-    Run a step-based pipeline and at the end run a series of post-processiong steps,
-    such as tracking of the whole time series.
-
-    Parameters
-    -----
-
-    Notes
-    -----
-    It returns the profiles in a tidy format
-    (i.e., the frame number or time point is its own column).
-
-    Assumptions:
-    - extraction fields start with 'ext', and then are followed by the object name (e.g., cyto, nuclei)
-    - The pipeline's output is nested in the following order: step -> time point -> tile.
-    """
-    output_path = Path(output_path)
-    steps_dir = output_path / "steps" / pipeline_name
-    profiles_file = output_path / "profiles" / f"{pipeline_name}.parquet"
-
-    profiles = None
-    post_results = None
-    # pipeline["io"].get("ntps", 2) #
-
-    # Main processing loop
-    if overwrite or not profiles_file.exists():
-        state = run_pipeline_return_state(pipeline, steps_dir=steps_dir)
-
-        # Aggregate profiles from the state output
-        profiles = get_profiles_from_state(state, pipeline)
-
-        # Save files (always write, even if empty, so re-runs skip and duckdb reads succeed)
-        profiles_file.parent.mkdir(parents=True, exist_ok=True)
-        pyarrow.parquet.write_table(profiles, profiles_file, compression="zstd")
-
-        # Save baby tracking/lineage if any segment step used baby
-        _save_baby_tracking_lineage(state, pipeline, output_path, pipeline_name)
-
-        # Run global processing steps (post-processing)
-        post_results = {}
-
-        # ntps = pipeline["io"]["ntps"]
-        # if ntps == 1:  # Temporarily do not perform global operations on non-timeseries
-        #     return profiles, post_results
-
-        for step_name, parameters in pipeline.get("global_steps", {}).items():
-            associated_data = [
-                x for x in pipeline["global_passed_data"] if x.startswith(step_name)
-            ]
-            assert len(associated_data), (
-                f"Incorrect pipeline: Missing information of which data to ingest for step {step_name}"
-            )
-            # TODO if nahual data is present, validate that the maximum target_label is below
-            # the maximum label in the profiles
-            for output_name in associated_data:
-                step_fn = init_step(step_name, parameters)
-
-                input_data = get_step_output(
-                    state["data"],
-                    pipeline["global_passed_data"][output_name],
-                    steps_dir=steps_dir,
-                )
-                post_result = step_fn(input_data=input_data)
-                post_results[output_name] = post_result
-
-            # Save global steps into files (per-tp steps are saved as they go, not at the end)
-            if step_name in pipeline["save"]:
-                write_fn = dispatch_write_fn(step_name)
-                for output_subdir in post_results:
-                    if output_subdir.startswith(step_name):
-                        write_fn(
-                            post_result,
-                            output_path,
-                            subpath=output_subdir,
-                            filename=pipeline_name,
-                        )
-    else:
-        logger.info(f"Skipping {pipeline_name}")
-        profiles, post_results = None, None
-
-    return profiles, post_results
-
-
-def get_profiles_from_state(state: dict, pipeline: dict) -> pyarrow.Table:
-    # Isolate features for every time point
-    # We assume that extraction steps start with "ext"
-    profiles = pyarrow.Table.from_pylist(
-        [],
-        schema=pa.schema(
-            [
-                pa.field("metadata_tile", pa.int64()),
-                pa.field("metadata_label", pa.int64()),
-                pa.field("metadata_object", pa.string()),
-                pa.field("metadata_tp", pa.int64()),
-            ]
-        ),
-    )
-    feature_steps = [
-        step_name
-        for step_name in pipeline["steps"]
-        if step_name.startswith("extract") or step_name.startswith("nahual_embed")
-    ]
-    # We will concatenate tables with the same number of colums horizontally
-    # and then join them on time point, tile and object columns
-    data = {k.split("_")[0]: [] for k in feature_steps}
-    for ext_step in feature_steps:
-        step_prefix = ext_step.split("_")[0]
-
-        # Data is stored in the following order: step -> time points -> tiles
-        for tp, ext_output in enumerate(state["data"][ext_step]):
-            if isinstance(ext_output, numpy.ndarray):  # Format arbitrary embedders
-                # We give it empty instructions that will be ignored
-                ext_output = (cycle((("__", "__"),)), (ext_output,))
-
-            table: pyarrow.PyTable = format_extraction(ext_output)
-            # Renamae map
-            rename_map = {
-                "tile": "metadata_tile",
-                "label": "metadata_label",
-            }
-            new_names = [rename_map.get(c, c) for c in table.column_names]
-            table = table.rename_columns(new_names)
-
-            if len(table):  # Cover case whence measurements are empty
-                # object name (cp_measure) or model name (nahual embedders)
-                table = table.append_column(
-                    "metadata_object",
-                    pyarrow.array(
-                        [ext_step.split("_")[-1]] * len(table), pyarrow.string()
-                    ),
-                )
-                table = table.append_column(
-                    "metadata_tp",
-                    pyarrow.array([tp] * len(table), pyarrow.uint8()),
-                )
-                data[step_prefix].append(table)
-
-    all_wide_tables = []
-    for k, wide_tables in data.items():
-        if len(wide_tables):
-            all_wide_tables.append(pyarrow.concat_tables(wide_tables))
-
-    # Create one wide table to rule them all, the final profiles
-    if all_wide_tables:
-        profiles = all_wide_tables[0]
-        for table in all_wide_tables[1:]:
-            profiles = profiles.join(
-                table,
-                keys=[f"metadata_{k}" for k in ("tp", "tile", "object", "label")],
-            )
-
-    return profiles
-
-
-def get_step_output(
-    state_data: dict,
-    fetchers: tuple[Callable | str],
-    steps_dir: Path | None = None,
-) -> numpy.ndarray:
-    """Dynamic fetcher for other outputs. It aggregates data over time points.
-
-    fetchers: each item may be
-        - a step-name string (read from in-memory state_data)
-        - "from_disk:<step_name>" (read per-tp .npz files from steps_dir/<step_name>)
-        - a callable applied to state_data
-    """
-    combined_outputs = []
-    for fetcher in fetchers:
-        if isinstance(fetcher, str):
-            if fetcher.startswith("from_disk:"):
-                if steps_dir is None:
-                    raise ValueError(
-                        "from_disk fetcher requires steps_dir; pass it through "
-                        "get_step_output(..., steps_dir=...)"
-                    )
-                step_name = fetcher.removeprefix("from_disk:")
-                aggregated_output = _load_per_tp_masks(Path(steps_dir) / step_name)
-            else:
-                # HACK: This is assuming a monotile, we should instead output always assuming tiles
-                aggregated_output = [x[0] for x in state_data[fetcher]]
-        elif isinstance(fetcher, Callable):
-            aggregated_output = fetcher(state_data)
-        else:
-            raise Exception(
-                f"Invalid type, expected Callable or string, got {type(fetcher)}"
-            )
-        combined_outputs.append(aggregated_output)
-
-    return numpy.asarray(combined_outputs)
-
-
-def _load_per_tp_masks(step_dir: Path) -> list[numpy.ndarray]:
-    """Read per-tp .npz mask files written by io.write.write_ndarray.
-
-    Mirrors the in-memory monotile slice ``[x[0] for x in state_data[step]]``
-    so trackastra (and any other consumer of get_step_output) sees identical
-    shapes whether masks come from RAM or disk.
-
-    Two on-disk formats are supported (see io/write.py:write_ndarray):
-      - baby segmenters: keys ``tile_0``, ``tile_1``, ... (one per tile)
-      - other segmenters: a single key ``arr_0`` holding a stacked
-        (tiles, Y, X) array
-    """
-    files = sorted(step_dir.glob("*.npz"))
-    if not files:
-        raise FileNotFoundError(
-            f"No per-tp .npz files found under {step_dir}; ensure this step "
-            f"is listed in pipeline['save']."
-        )
-    masks = []
-    for f in files:
-        with numpy.load(f) as npz:
-            keys = list(npz.keys())
-            if "tile_0" in keys:
-                masks.append(npz["tile_0"])
-            elif keys == ["arr_0"]:
-                stacked = npz["arr_0"]
-                masks.append(stacked[0])
-            else:
-                raise ValueError(f"Unrecognised .npz layout in {f}: keys={keys}")
-    return masks
+run_pipeline_and_post = partial(
+    _run_pipeline_and_post_impl, init_step_fn=init_step, post_state_hook=None
+)
+
+
+__all__ = [
+    "configure_logging",
+    "get_profiles_from_state",
+    "get_step_output",
+    "init_step",
+    "pipeline_step",
+    "run_pipeline_and_post",
+    "run_pipeline_return_state",
+    "run_step",
+    "slice_channels_process",
+    "validate_pipeline",
+]

--- a/src/aliby/pipe_baby.py
+++ b/src/aliby/pipe_baby.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env jupyter
+"""
+BABY (nahual_baby) pipeline.
+
+Runs BABY remotely via Nahual for segmentation and tracking. BABY produces
+overlapping per-tile masks plus tracking/lineage metadata that is extracted
+post-run via the ``_save_baby_tracking_lineage`` post-state hook.
+
+Still supports Nahual embedders alongside BABY segmentation.
+"""
+
+from functools import partial
+from pathlib import Path
+from typing import Callable
+
+import pyarrow
+from loguru import logger
+
+from aliby.pipe_core import (
+    _init_extract,
+    _init_nahual_embed,
+    _init_nahual_track,
+    _init_tile,
+    _run_pipeline_and_post_impl,
+)
+from aliby.segment.dispatch import dispatch_segmenter
+from aliby.track.dispatch import dispatch_tracker
+
+
+def _init_segment_baby(step_name: str, parameters: dict, other_steps: dict) -> Callable:
+    """BABY segmenter — requires a preceding ``tile`` step; the tiler instance
+    is injected into the segmenter so BABY can pull pixels itself."""
+    seg_kwargs = parameters.get("segmenter_kwargs", {})
+    tiler_step = next((v for k, v in other_steps.items() if k.startswith("tile")), None)
+    if tiler_step is None:
+        raise ValueError(
+            f"Step '{step_name}' using 'baby' requires a preceding 'tile' step."
+        )
+    seg_kwargs["tiler"] = tiler_step
+    if "channel_to_segment" not in parameters:
+        raise ValueError(
+            f"Step '{step_name}' is missing required 'channel_to_segment'."
+        )
+    return dispatch_segmenter(
+        channel_to_segment=parameters["channel_to_segment"],
+        **seg_kwargs,
+    )
+
+
+def _init_track_baby(step_name: str, parameters: dict, other_steps: dict) -> Callable:
+    """BABY tracker — pulls the crawler from the segment step."""
+    segment_step = next(
+        (v for k, v in other_steps.items() if k.startswith("segment")), None
+    )
+    if segment_step is None:
+        raise ValueError(
+            f"Step '{step_name}' using 'baby' tracking requires a preceding 'segment' step."
+        )
+    parameters["crawler"] = segment_step.crawler
+    return dispatch_tracker(**parameters)
+
+
+def init_step(
+    step_name: str,
+    parameters: dict,
+    other_steps: dict | None = None,
+) -> Callable:
+    """Set up parameters for any step in the BABY pipeline."""
+    if other_steps is None:
+        other_steps = {}
+
+    match step_name:
+        case s if s.startswith("tile"):
+            return _init_tile(s, parameters)
+        case s if s.startswith("segment"):
+            return _init_segment_baby(s, parameters, other_steps)
+        case s if s.startswith("track"):
+            return _init_track_baby(s, parameters, other_steps)
+        case s if s.startswith("extract_"):
+            return _init_extract(s, parameters, overlap=True)
+        case s if s.startswith("extractmulti_"):
+            raise ValueError(
+                "Multi-channel colocalization extraction is not supported with "
+                "BABY's overlapping masks."
+            )
+        case s if s.startswith("nahual_embed"):
+            return _init_nahual_embed(s, parameters)
+        case s if s.startswith("nahual_track"):
+            return _init_nahual_track(s, parameters)
+        case _:
+            raise ValueError(f"Invalid step name {step_name=}")
+
+
+def _save_baby_tracking_lineage(
+    state: dict, pipeline: dict, output_path: Path, pipeline_name: str
+) -> None:
+    """Extract and save BABY tracking/lineage from segment metadata across timepoints."""
+    for step_name in pipeline["steps"]:
+        if not step_name.startswith("segment"):
+            continue
+        seg_kwargs = pipeline["steps"][step_name].get("segmenter_kwargs", {})
+        if not seg_kwargs.get("kind", "").endswith("baby"):
+            continue
+
+        step_data = state["data"].get(step_name, [])
+        baby_meta_history = [
+            tp_result["metadata"]
+            for tp_result in step_data
+            if isinstance(tp_result, dict) and "metadata" in tp_result
+        ]
+        if not baby_meta_history:
+            continue
+
+        from aliby.segment.baby_parser import (
+            accumulate_lineage,
+            accumulate_tracking,
+            baby_tracking_to_table,
+        )
+
+        tracking = accumulate_tracking(baby_meta_history)
+        lineage = accumulate_lineage(baby_meta_history)
+        table = baby_tracking_to_table(tracking, lineage)
+
+        if len(table):
+            tracking_dir = output_path / "tracking"
+            tracking_dir.mkdir(parents=True, exist_ok=True)
+            out_file = tracking_dir / f"{pipeline_name}_{step_name}.parquet"
+            pyarrow.parquet.write_table(table, out_file, compression="zstd")
+            logger.info(f"Saved baby tracking/lineage to {out_file}")
+
+
+run_pipeline_and_post = partial(
+    _run_pipeline_and_post_impl,
+    init_step_fn=init_step,
+    post_state_hook=_save_baby_tracking_lineage,
+)

--- a/src/aliby/pipe_builder.py
+++ b/src/aliby/pipe_builder.py
@@ -1,27 +1,25 @@
 #!/usr/bin/env python
+"""
+Builder for the Cellpose + cp_measure pipeline (the standard).
+
+Defaults to local Cellpose. If ``nahual_addresses`` is provided, switches to
+``nahual_cellpose``. Always includes single-channel feature extraction and
+multi-channel colocalization. Optional Nahual trackastra is wired in via
+``pipe_core._attach_trackastra``.
+
+For BABY, see ``aliby.pipe_builder_baby``.
+"""
 
 from itertools import combinations, product
 from typing import Sequence
+
+from aliby.pipe_core import _attach_trackastra
 
 
 def _create_extract_multich_tree(
     channels: Sequence[int], extract_ncores: int | None
 ) -> dict:
-    """
-    Generate the extract_multich_tree dictionary for colocalization.
-
-    Parameters
-    ----------
-    channels : Sequence of int
-        Sequence of channel indices to consider for colocalization.
-    extract_ncores : int or None
-        Number of cores to use for extraction.
-
-    Returns
-    -------
-    dict
-        Dictionary containing the multich tree.
-    """
+    """Build the extract_multich tree dict for colocalization."""
     return {
         "tree": {
             pair: {
@@ -47,164 +45,81 @@ def build_pipeline_steps(
         "texture",
         "radial_distribution",
         "zernike",
-        # "granularity", # Too time-consuming, deactivated for now
     ),
     extract_ncores: int | None = None,
     nahual_addresses: str | Sequence[str] | None = None,
-    devices: Sequence[int] | None = None,
     steps_to_write: Sequence[str] | None = None,
-    segmenter_kind: str | None = None,
-    baby_modelset: str | None = None,
-    baby_address: str | None = None,
     trackastra_address: str | None = None,
     trackastra_parameters: dict | None = None,
 ) -> dict:
-    """
-    Convenience function to build a pipeline definition, does not fill in IO.
+    """Build a Cellpose + cp_measure pipeline definition (no IO).
 
     Parameters
     ----------
-    channels_to_segment : dict of {str: int} or None, default=None
-        Dictionary mapping object names to their respective channel indices.
-        If None, defaults to `{"nuclei": 1, "cell": 0}`.
-    channels_to_extract : Sequence of int or None, default=None
-        Sequence of channel indices from which to extract features. If None, it
-        uses all values from `channels_to_segment`.
-    features_to_extract : Sequence of str, default=("radial_zernikes", ...)
-        Sequence of feature types to extract for each extracted channel.
-    extract_ncores : int or None, default=None
-        Number of CPU cores to use for feature extraction.
-    nahual_addresses : str or Sequence of str or None, default=None
-        Address(es) of the Nahual servers for remote segmentation.
-    devices : Sequence of int or None, default=None
-        Sequence of device IDs to distribute Nahual segmentation across.
-    steps_to_write : Sequence of str or None, default=None
-        Sequence of steps whose outputs should be saved (e.g., written to disk).
-        If None, defaults to all keys in `channels_to_segment`.
-
-    Returns
-    -------
-    dict
-        A dictionary defining the pipeline configuration. Expected keys include:
-
-        - ``steps`` (dict): Dictionary mapping step names to their parameter dictionaries.
-          Used to instantiate pipeline steps via `init_step`.
-        - ``passed_data`` (dict): Specifies which outputs from previous steps should be
-          passed as arguments to a given step. Format is
-          `{step_name: [(parameter_key, from_step, *optional_varname), ...]}`.
-        - ``passed_methods`` (dict): Specifies methods to call on previous step objects to
-          retrieve data. Format is `{step_name: (source_step, method_name)}`.
-        - ``save`` (list of str): List of step names whose outputs should be saved to disk.
-        - ``save_interval`` (int): Interval (in time points) at which to save outputs.
+    channels_to_segment : dict of {str: int} or None
+        Mapping object name → channel index. Defaults to ``{"nuclei": 1, "cell": 0}``.
+    channels_to_extract : Sequence of int or None
+        Channels to extract features from. Defaults to all values in ``channels_to_segment``.
+    features_to_extract : Sequence of str
+        cp_measure feature names to compute per extracted channel.
+    extract_ncores : int or None
+        Cores for joblib-parallelised extraction.
+    nahual_addresses : str or Sequence of str or None
+        If provided, segmentation runs remotely via Nahual (kind=``nahual_cellpose``).
+    steps_to_write : Sequence of str or None
+        Step names whose outputs are written to disk. Defaults to segment steps.
+    trackastra_address, trackastra_parameters
+        If both provided, attach a ``nahual_trackastra`` global step.
     """
-
     if channels_to_segment is None:
         channels_to_segment = {"nuclei": 1, "cell": 0}
 
     use_nahual = nahual_addresses is not None
-    distribute_across_devices = devices is not None
-
-    if segmenter_kind is None:
-        segmenter_kind = "cellpose"
-        if use_nahual:
-            segmenter_kind = "nahual_cellpose"
-
-    use_baby = segmenter_kind == "nahual_baby"
-
-    if distribute_across_devices:  # Randomly assign Nahual_Cellpose instances
-        assert isinstance(nahual_addresses, list), (
-            "`nahual_addresses must` be specified distributing across devices"
-        )
-        n_devices = len(devices)
-        n_addresses = len(addresses)
-
-        hashed_input = hash(str(input_path))
-        device_id = hashed_input % n_devices
+    segmenter_kind = "nahual_cellpose" if use_nahual else "cellpose"
 
     if channels_to_extract is None:
         channels_to_extract = list(channels_to_segment.values())
 
-    # Build parameter names
     seg_params = {}
-    for i, (obj, ch_id) in enumerate(channels_to_segment.items()):
+    for obj, ch_id in channels_to_segment.items():
         step_name = f"segment_{obj}"
-        skwargs = dict(kind=segmenter_kind)
-        if segmenter_kind == "nahual_baby":
-            skwargs["address"] = baby_address
-            skwargs["modelset"] = baby_modelset
         seg_params[step_name] = dict(
-            segmenter_kwargs=skwargs,
+            segmenter_kwargs=dict(kind=segmenter_kind),
             channel_to_segment=ch_id,
         )
-        if use_baby:
-            assert baby_address is not None, "baby_address required for nahual_baby"
-            assert baby_modelset is not None, "baby_modelset required for nahual_baby"
-            seg_params[step_name]["segmenter_kwargs"]["address"] = baby_address
-            seg_params[step_name]["segmenter_kwargs"]["modelset"] = baby_modelset
-        if distribute_across_devices:
-            seg_params[step_name]["segmenter_kwargs"]["address"] = addresses[
-                hashed_input % n_addresses
-            ]
-            seg_params[step_name]["segmenter_kwargs"]["setup_params"] = (
-                hashed_input % n_devices
-            )
 
     extract_base = dict(
         tree={"None": {"None": ("sizeshape",)}},
         kwargs=dict(ncores=extract_ncores),
     )
-    if use_baby:
-        extract_base["overlap"] = True
     for i in channels_to_extract:
-        extract_base["tree"][i] = {
-            "max": features_to_extract,
-        }
+        extract_base["tree"][i] = {"max": features_to_extract}
+
     extract_multich_base = _create_extract_multich_tree(
         channels_to_extract, extract_ncores
     )
 
-    # Build extraction parameters using segmentation
-    # Multi-channel extraction doesn't support baby's overlapping masks
-    extract_variants = [("", extract_base)]
-    if not use_baby:
-        extract_variants.append(("multi", extract_multich_base))
+    extract_variants = [("", extract_base), ("multi", extract_multich_base)]
     ext_params = {
         f"extract{name}_{obj}": var
-        for (name, var), obj in product(
-            extract_variants,
-            channels_to_segment,
-        )
+        for (name, var), obj in product(extract_variants, channels_to_segment)
         if len(var)
     }
 
     base_pipeline = {
         "steps": dict(
-            tile=dict(
-                # These should be provided outside
-                # image_kwargs=dict(
-                #     source=input_path,
-                #     # regex=regex,
-                #     # capture_order=fluo_base_config["capture_order"],
-                #     # dimorder=fluo_base_config["dimorder"],
-                # ),
-                tile_size=None,  # default value
-                # ref_channel=0,
-                # ref_z=0,
-                # calculate_drift=False,
-            ),
+            tile=dict(tile_size=None),
             **seg_params,
             **ext_params,
         ),
-        "passed_data": dict(
-            **{
-                f"extract{multi}_{obj}": [
-                    ("masks", f"segment_{obj}"),
-                    ("pixels", "tile"),
-                ]
-                for obj in channels_to_segment
-                for multi in ([n for n, _ in extract_variants])
-            },
-        ),
+        "passed_data": {
+            f"extract{multi}_{obj}": [
+                ("masks", f"segment_{obj}"),
+                ("pixels", "tile"),
+            ]
+            for obj in channels_to_segment
+            for multi in (n for n, _ in extract_variants)
+        },
         "passed_methods": {
             f"segment_{obj}": ("tile", "get_fczyx") for obj in channels_to_segment
         },
@@ -216,45 +131,11 @@ def build_pipeline_steps(
         base_pipeline["save"] = list(steps_to_write)
 
     if trackastra_address is not None:
-        # Disk-backed trackastra: per-tp segment masks are saved by the main
-        # loop, then nahual_trackastra reads them back via the "from_disk:"
-        # fetcher. This keeps state["data"]["segment_*"] bounded by retain=2
-        # (per-tp tracker still needs the last 2 timepoints in RAM) instead
-        # of growing with T.
-        seg_step_names = [f"segment_{obj}" for obj in channels_to_segment]
-        for seg in seg_step_names:
-            if seg not in base_pipeline["save"]:
-                base_pipeline["save"].append(seg)
-        base_pipeline["save"].append("nahual_trackastra")
-
-        base_pipeline["global_steps"] = {
-            "nahual_trackastra": dict(
-                address=trackastra_address,
-                parameters=trackastra_parameters or {},
-            ),
-        }
-        base_pipeline["global_passed_data"] = {
-            f"nahual_trackastra_{obj}": (f"from_disk:segment_{obj}",)
-            for obj in channels_to_segment
-        }
-
-        retain = base_pipeline.setdefault("retain", {})
-        for seg in seg_step_names:
-            retain.setdefault(seg, 2)
-        retain.setdefault("tile", 1)
+        _attach_trackastra(
+            base_pipeline,
+            channels_to_segment,
+            trackastra_address,
+            trackastra_parameters,
+        )
 
     return base_pipeline
-
-    # try:
-    # fov = input_path["key"]  # TODO Homogeneize how to name experiments
-    # return fov, base_pipeline
-
-    # result, _ = run_pipeline_and_post(
-    #     pipeline=base_pipeline,
-    #     img_source=input_path,
-    #     output_path=output_path,
-    #     fov=fov,
-    #     overwrite=False,
-    # )
-    # except Exception as e:
-    #     print(f"Error: {e}")

--- a/src/aliby/pipe_builder_baby.py
+++ b/src/aliby/pipe_builder_baby.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python
+"""
+Builder for the BABY (nahual_baby) pipeline.
+
+Hard-wired to ``kind="nahual_baby"``. Always uses overlapping-mask extraction.
+Multi-channel colocalization extraction is not emitted (BABY's overlapping masks
+break the coloc routine). Segment steps do NOT receive ``passed_methods`` —
+BABY pulls pixels via the tiler injected at init time.
+"""
+
+from typing import Sequence
+
+from aliby.pipe_core import _attach_trackastra
+
+
+def build_pipeline_steps(
+    baby_address: str,
+    baby_modelset: str,
+    channels_to_segment: dict[str, int] | None = None,
+    channels_to_extract: Sequence[int] | None = None,
+    features_to_extract: Sequence[str] = (
+        "radial_zernikes",
+        "intensity",
+        "feret",
+        "texture",
+        "radial_distribution",
+        "zernike",
+    ),
+    extract_ncores: int | None = None,
+    steps_to_write: Sequence[str] | None = None,
+    trackastra_address: str | None = None,
+    trackastra_parameters: dict | None = None,
+) -> dict:
+    """Build a BABY pipeline definition (no IO).
+
+    Parameters
+    ----------
+    baby_address : str
+        Address of the Nahual server hosting BABY (required).
+    baby_modelset : str
+        BABY modelset name to load (required).
+    channels_to_segment : dict of {str: int} or None
+        Mapping object name → channel index. Defaults to ``{"nuclei": 1, "cell": 0}``.
+    channels_to_extract, features_to_extract, extract_ncores, steps_to_write,
+    trackastra_address, trackastra_parameters
+        See ``pipe_builder.build_pipeline_steps``.
+    """
+    if channels_to_segment is None:
+        channels_to_segment = {"nuclei": 1, "cell": 0}
+
+    if channels_to_extract is None:
+        channels_to_extract = list(channels_to_segment.values())
+
+    seg_params = {}
+    for obj, ch_id in channels_to_segment.items():
+        step_name = f"segment_{obj}"
+        seg_params[step_name] = dict(
+            segmenter_kwargs=dict(
+                kind="nahual_baby",
+                address=baby_address,
+                modelset=baby_modelset,
+            ),
+            channel_to_segment=ch_id,
+        )
+
+    # overlap=True is enforced by pipe_baby.init_step, not via the params dict.
+    extract_base = dict(
+        tree={"None": {"None": ("sizeshape",)}},
+        kwargs=dict(ncores=extract_ncores),
+    )
+    for i in channels_to_extract:
+        extract_base["tree"][i] = {"max": features_to_extract}
+
+    # BABY emits one extract step per object; no extractmulti_* variant.
+    ext_params = {f"extract_{obj}": extract_base for obj in channels_to_segment}
+
+    base_pipeline = {
+        "steps": dict(
+            tile=dict(tile_size=None),
+            **seg_params,
+            **ext_params,
+        ),
+        "passed_data": {
+            f"extract_{obj}": [
+                ("masks", f"segment_{obj}"),
+                ("pixels", "tile"),
+            ]
+            for obj in channels_to_segment
+        },
+        # No passed_methods for segment steps: BABY's tiler is injected at init
+        # time and BABY pulls pixels itself.
+        "passed_methods": {},
+        "save": [f"segment_{obj}" for obj in channels_to_segment.keys()],
+        "save_interval": 1,
+    }
+
+    if steps_to_write is not None:
+        base_pipeline["save"] = list(steps_to_write)
+
+    if trackastra_address is not None:
+        _attach_trackastra(
+            base_pipeline,
+            channels_to_segment,
+            trackastra_address,
+            trackastra_parameters,
+        )
+
+    return base_pipeline

--- a/src/aliby/pipe_core.py
+++ b/src/aliby/pipe_core.py
@@ -1,0 +1,607 @@
+#!/usr/bin/env jupyter
+"""
+Pipeline core: shared, segmenter-agnostic engine.
+
+Pipelines (pipe, pipe_baby) build on top of this by providing their
+own ``init_step`` dispatcher and binding ``run_pipeline_and_post`` with a
+pipeline-specific ``post_state_hook``.
+"""
+
+from functools import partial
+from itertools import cycle
+from pathlib import Path
+from typing import Callable, Sequence
+
+import numcodecs
+import numpy
+import pyarrow
+import pyarrow as pa
+from imagecodecs.numcodecs import Jpegxl
+from loguru import logger
+
+from aliby.global_steps import dispatch_global_step
+from aliby.io.image import dispatch_image
+from aliby.io.write import dispatch_write_fn
+from aliby.tile.tiler import dispatch_tiler
+from extraction.extract import (
+    extract_tree,
+    extract_tree_multi,
+    format_extraction,
+    process_tree_masks,
+    process_tree_masks_overlap,
+)
+
+numcodecs.register_codec(Jpegxl)
+
+
+def configure_logging(file):
+    logger.remove()
+    logger.add(
+        file,
+        rotation="10 MB",
+        retention="1 week",
+        compression="zip",
+        level="DEBUG",
+        format="{time:YYYY-MM-DD HH:mm:ss.SSS} | {level: <8} | {name}:{function}:{line} - {message}",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Shared init helpers (used by both pipelines' init_step dispatchers)
+# ---------------------------------------------------------------------------
+
+
+def _init_tile(step_name: str, parameters: dict) -> Callable:
+    image_kwargs = parameters.pop("image_kwargs", None)
+    if image_kwargs is None:
+        raise ValueError(f"Step '{step_name}' is missing required 'image_kwargs'.")
+    if "source" not in image_kwargs:
+        raise ValueError(
+            f"Step '{step_name}' 'image_kwargs' is missing required 'source'."
+        )
+    tiler_constructor = dispatch_tiler(parameters.pop("kind", None), parameters)
+    image_type = dispatch_image(source=image_kwargs["source"])
+    image = image_type(**image_kwargs)
+    return tiler_constructor(image)
+
+
+def _init_extract(step_name: str, parameters: dict, *, overlap: bool) -> Callable:
+    if "tree" not in parameters:
+        raise ValueError(f"Step '{step_name}' is missing required 'tree'.")
+    process = process_tree_masks
+    measure_fn = extract_tree
+    if overlap:
+        process = process_tree_masks_overlap
+        measure_fn = partial(extract_tree, overlap=True)
+    return partial(
+        process,
+        measure_fn=measure_fn,
+        tree=parameters["tree"],
+        **parameters.get("kwargs", {}),
+    )
+
+
+def _init_extract_multi(step_name: str, parameters: dict) -> Callable:
+    if "tree" not in parameters:
+        raise ValueError(f"Step '{step_name}' is missing required 'tree'.")
+    return partial(
+        process_tree_masks,
+        measure_fn=extract_tree_multi,
+        tree=parameters["tree"],
+        **parameters.get("kwargs", {}),
+    )
+
+
+def _init_nahual_embed(step_name: str, parameters: dict) -> Callable:
+    address = parameters.get("address")
+    if address is None:
+        raise ValueError(
+            f"If using Nahual you must have an address, currently it is None in step '{step_name}'"
+        )
+    if "setup_params" not in parameters:
+        raise ValueError(f"Nahual embed step '{step_name}' is missing 'setup_params'.")
+    if "model_group" not in parameters:
+        raise ValueError(f"Nahual embed step '{step_name}' is missing 'model_group'.")
+
+    from nahual.process import dispatch_setup_process
+
+    setup, process = dispatch_setup_process(parameters["model_group"])
+
+    selected_channels = parameters.get("selected_channels")
+    if selected_channels:
+        process = partial(
+            slice_channels_process,
+            process=process,
+            selected_channels=selected_channels,
+        )
+
+    info = setup(parameters["setup_params"], address=address)
+    print(f"Embedder via nahual set up. Remote returned {info}")
+    return partial(process, address=address)
+
+
+def _init_nahual_track(step_name: str, parameters: dict) -> Callable:
+    address = parameters.get("address")
+    if address is None:
+        raise ValueError(
+            f"If using Nahual you must have an address, currently it is None in step '{step_name}'"
+        )
+    if "parameters" not in parameters:
+        raise ValueError(f"Nahual track step '{step_name}' is missing 'parameters'.")
+    setup, process = dispatch_global_step(step_name)
+    setup_output = setup(parameters["parameters"], address=address)
+    print(f"NAHUAL: Remote process set up, returned {setup_output}.")
+    return partial(process, address=address)
+
+
+def slice_channels_process(
+    data: numpy.ndarray,
+    process: Callable,
+    selected_channels: list[int] | numpy.ndarray,
+    **kwargs,
+) -> numpy.ndarray:
+    """Apply a processing function to a subset of channels in a NumPy array."""
+    return process(data[:, selected_channels], **kwargs)
+
+
+def run_step(step, *args, **kwargs):
+    if hasattr(step, "run_tp"):  # older OO-style
+        result = step.run_tp(*args, **kwargs)
+    else:
+        if "tp" in kwargs:
+            del kwargs["tp"]
+        result = step(*args, **kwargs)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Per-tp loop and post-processing
+# ---------------------------------------------------------------------------
+
+
+def pipeline_step(
+    pipeline: dict,
+    state: dict | None,
+    steps_dir: str | None,
+    init_step_fn: Callable,
+) -> dict:
+    """Run one timepoint of the pipeline using the provided init_step_fn."""
+    if state is None:
+        state = {}
+
+    steps = pipeline["steps"]
+    passed_methods = pipeline.get("passed_methods", {})
+
+    if not state:
+        state = {"tps": dict(zip(steps, cycle([0]))), "data": {}, "fn": {}}
+    tp = next(iter(state["tps"].values()))
+
+    for step_name, parameters in steps.items():
+        if step_name not in state["data"]:
+            state["data"][step_name] = []
+        if step_name not in state["fn"]:
+            state["fn"][step_name] = init_step_fn(step_name, parameters, state["fn"])
+        step = state["fn"][step_name]
+
+        # Pull data from previous steps via passed_data spec.
+        # Format: {consumer_step: [(arg_name, producer_step, *opt_var), ...]}
+        this_step_receives = pipeline["passed_data"].get(step_name, {})
+        passed_data = {}
+        for kwd, from_step, *varname in this_step_receives:
+            passed_value = state["data"].get(from_step, [])
+            step_argname = varname[0] if varname else kwd
+
+            if len(passed_value):
+                if step_name == "track" and kwd == "masks":
+                    # tracker reads last 2 timepoints; reshape tp,tile,y,x -> tile,tp,y,x
+                    passed_data[step_argname] = [
+                        [tp_tiles[tile] for tp_tiles in passed_value[-2:]]
+                        for tile in range(len(passed_value[-1]))
+                    ]
+                else:
+                    last_value = passed_value[-1]
+                    if isinstance(last_value, dict):
+                        last_value = last_value[kwd]
+                    passed_data[step_argname] = last_value
+
+        # Pull pixels from a method on a previous-step object when configured.
+        # Cellpose builder emits passed_methods[segment_*] = ("tile", "get_fczyx").
+        # BABY builder does NOT emit one for segment steps because BABY pulls
+        # pixels through its embedded tiler (injected at init time).
+        args = ()
+        method_spec = passed_methods.get(step_name)
+        if method_spec is not None and step_name.startswith("segment"):
+            source_step, method = method_spec
+            args = (getattr(state["fn"][source_step], method)(tp),)
+
+        step_result = run_step(step, *args, tp=tp, **passed_data)
+
+        # Save outputs that are listed in pipeline["save"]
+        steps_to_write = pipeline.get("save") or []
+        save_interval = pipeline.get("save_interval", 1)
+        should_save = (
+            bool(steps_to_write) and save_interval > 0 and (tp % save_interval) == 0
+        )
+        if should_save and step_name in steps_to_write:
+            print(f"Saving {step_name} to {steps_dir}")
+            write_fn = dispatch_write_fn(step_name)
+            write_fn(step_result, steps_dir=steps_dir, subpath=step_name, tp=tp)
+
+        state["data"][step_name].append(step_result)
+        if step_name not in state["fn"]:
+            state["fn"][step_name] = step
+        state["tps"][step_name] = tp + 1
+
+    # End-of-tp memory hygiene.
+    # Drop the raw pixel block from the last tile entry: tile pixels are only
+    # consumed within the same tp via passed_data and never re-read after.
+    for step_name in state["data"]:
+        if step_name.startswith("tile"):
+            entry = state["data"][step_name][-1] if state["data"][step_name] else None
+            if isinstance(entry, dict) and "pixels" in entry:
+                del entry["pixels"]
+
+    # Trim per-step history per the pipeline's "retain" config.
+    retain_cfg = pipeline.get("retain", {})
+    for step_name, history in state["data"].items():
+        keep = retain_cfg.get(step_name, "all")
+        if isinstance(keep, int) and keep >= 0 and len(history) > keep:
+            del history[: len(history) - keep]
+
+    return state
+
+
+def validate_pipeline(pipeline: dict) -> None:
+    if not isinstance(pipeline, dict):
+        raise TypeError("Pipeline configuration must be a dictionary.")
+
+    if "steps" not in pipeline or not isinstance(pipeline["steps"], dict):
+        raise ValueError(
+            "Pipeline must contain a 'steps' dictionary mapping step names to parameters."
+        )
+
+    steps = pipeline["steps"]
+
+    if "passed_data" not in pipeline or not isinstance(pipeline["passed_data"], dict):
+        raise ValueError("Pipeline must contain a 'passed_data' dictionary.")
+
+    passed_data = pipeline["passed_data"]
+    for target_step, dependencies in passed_data.items():
+        if not isinstance(dependencies, (list, tuple)):
+            raise TypeError(
+                f"'passed_data' dependencies for step '{target_step}' must be a sequence."
+            )
+        for dep in dependencies:
+            if not isinstance(dep, (list, tuple)) or len(dep) < 2:
+                raise ValueError(
+                    f"Invalid dependency format in 'passed_data' for '{target_step}': {dep}"
+                )
+            from_step = dep[1]
+            if from_step not in steps:
+                raise ValueError(
+                    f"Step '{target_step}' expects data from '{from_step}', but '{from_step}' is not defined in 'steps'."
+                )
+
+    passed_methods = pipeline.get("passed_methods", {})
+    if not isinstance(passed_methods, dict):
+        raise TypeError("'passed_methods' must be a dictionary.")
+    for target_step, method_dep in passed_methods.items():
+        if not isinstance(method_dep, (list, tuple)) or len(method_dep) < 2:
+            raise ValueError(
+                f"Invalid method dependency format for '{target_step}': {method_dep}"
+            )
+        from_step = method_dep[0]
+        if from_step not in steps:
+            raise ValueError(
+                f"Step '{target_step}' expects a method from '{from_step}', but '{from_step}' is not defined in 'steps'."
+            )
+
+    steps_to_write = pipeline.get("save")
+    if steps_to_write is not None:
+        if not isinstance(steps_to_write, (list, tuple, set)):
+            raise TypeError("'save' must be a sequence of step names.")
+        for step in steps_to_write:
+            if step not in steps and step not in pipeline.get("global_steps", {}):
+                raise ValueError(
+                    f"Step '{step}' listed in 'save' is not defined in the pipeline 'steps' or 'global_steps'."
+                )
+
+    if "save_interval" in pipeline:
+        save_interval = pipeline["save_interval"]
+        if (
+            not isinstance(save_interval, int)
+            or isinstance(save_interval, bool)
+            or save_interval < 1
+        ):
+            raise ValueError(
+                f"'save_interval' must be a positive int, got {save_interval!r}."
+            )
+
+    retain = pipeline.get("retain", {})
+    if not isinstance(retain, dict):
+        raise TypeError(
+            "'retain' must be a dictionary mapping step name to int or 'all'."
+        )
+    for step_name, keep in retain.items():
+        if step_name not in steps:
+            raise ValueError(
+                f"'retain' references step '{step_name}' not defined in 'steps'."
+            )
+        if keep != "all" and not (
+            isinstance(keep, int) and not isinstance(keep, bool) and keep >= 0
+        ):
+            raise ValueError(
+                f"'retain[{step_name}]' must be a non-negative int or 'all', got {keep!r}."
+            )
+        track_reads_segment = any(
+            from_step == step_name
+            for target, deps in passed_data.items()
+            if target.startswith("track")
+            for dep in deps
+            if (from_step := dep[1])
+        )
+        if track_reads_segment and isinstance(keep, int) and keep < 2:
+            raise ValueError(
+                f"'retain[{step_name}]' = {keep} is too small; per-tp 'track' step "
+                f"reads the last 2 timepoints of '{step_name}'."
+            )
+
+    for k, params in steps.items():
+        if not isinstance(params, dict):
+            raise TypeError(f"Parameters for step '{k}' must be a dictionary.")
+        if k.startswith("nahual"):
+            if "address" not in params:
+                raise ValueError(
+                    f"Nahual-deployed step '{k}' must provide an 'address' parameter."
+                )
+
+    global_steps = pipeline.get("global_steps", {})
+    if global_steps:
+        if "global_passed_data" not in pipeline:
+            raise ValueError(
+                "Pipeline defines 'global_steps' but is missing 'global_passed_data'."
+            )
+        if not isinstance(pipeline["global_passed_data"], dict):
+            raise TypeError("'global_passed_data' must be a dictionary.")
+
+
+def run_pipeline_return_state(
+    pipeline: dict,
+    steps_dir: str | None,
+    init_step_fn: Callable,
+) -> dict:
+    validate_pipeline(pipeline)
+    state = {}
+    ntps = pipeline.get("ntps", 1)
+    for _ in range(ntps):
+        state = pipeline_step(pipeline, state, steps_dir, init_step_fn)
+    return state
+
+
+def _run_pipeline_and_post_impl(
+    pipeline: dict,
+    pipeline_name: str,
+    output_path: str | Path,
+    overwrite: bool = True,
+    *,
+    init_step_fn: Callable,
+    post_state_hook: Callable | None = None,
+) -> tuple[pyarrow.Table, dict | None]:
+    """Run a step-based pipeline and any post-processing global steps.
+
+    Parameters
+    ----------
+    init_step_fn
+        Pipeline-specific step initialiser (cellpose or baby flavour).
+    post_state_hook
+        Optional callable ``(state, pipeline, output_path, pipeline_name) -> None``
+        invoked after profiles are written and before global steps. Used by the
+        BABY pipeline to extract tracking/lineage from segmenter metadata.
+    """
+    output_path = Path(output_path)
+    steps_dir = output_path / "steps" / pipeline_name
+    profiles_file = output_path / "profiles" / f"{pipeline_name}.parquet"
+
+    profiles = None
+    post_results = None
+
+    if overwrite or not profiles_file.exists():
+        state = run_pipeline_return_state(pipeline, steps_dir, init_step_fn)
+        profiles = get_profiles_from_state(state, pipeline)
+
+        profiles_file.parent.mkdir(parents=True, exist_ok=True)
+        pyarrow.parquet.write_table(profiles, profiles_file, compression="zstd")
+
+        if post_state_hook is not None:
+            post_state_hook(state, pipeline, output_path, pipeline_name)
+
+        post_results = {}
+        for step_name, parameters in pipeline.get("global_steps", {}).items():
+            associated_data = [
+                x for x in pipeline["global_passed_data"] if x.startswith(step_name)
+            ]
+            assert len(associated_data), (
+                f"Incorrect pipeline: Missing information of which data to ingest for step {step_name}"
+            )
+            for output_name in associated_data:
+                step_fn = init_step_fn(step_name, parameters)
+                input_data = get_step_output(
+                    state["data"],
+                    pipeline["global_passed_data"][output_name],
+                    steps_dir=steps_dir,
+                )
+                post_result = step_fn(input_data=input_data)
+                post_results[output_name] = post_result
+
+            if step_name in pipeline["save"]:
+                write_fn = dispatch_write_fn(step_name)
+                for output_subdir in post_results:
+                    if output_subdir.startswith(step_name):
+                        write_fn(
+                            post_result,
+                            output_path,
+                            subpath=output_subdir,
+                            filename=pipeline_name,
+                        )
+    else:
+        logger.info(f"Skipping {pipeline_name}")
+        profiles, post_results = None, None
+
+    return profiles, post_results
+
+
+def get_profiles_from_state(state: dict, pipeline: dict) -> pyarrow.Table:
+    profiles = pyarrow.Table.from_pylist(
+        [],
+        schema=pa.schema(
+            [
+                pa.field("metadata_tile", pa.int64()),
+                pa.field("metadata_label", pa.int64()),
+                pa.field("metadata_object", pa.string()),
+                pa.field("metadata_tp", pa.int64()),
+            ]
+        ),
+    )
+    feature_steps = [
+        step_name
+        for step_name in pipeline["steps"]
+        if step_name.startswith("extract") or step_name.startswith("nahual_embed")
+    ]
+    data = {k.split("_")[0]: [] for k in feature_steps}
+    for ext_step in feature_steps:
+        step_prefix = ext_step.split("_")[0]
+        for tp, ext_output in enumerate(state["data"][ext_step]):
+            if isinstance(ext_output, numpy.ndarray):  # arbitrary embedders
+                ext_output = (cycle((("__", "__"),)), (ext_output,))
+            table: pyarrow.Table = format_extraction(ext_output)
+            rename_map = {"tile": "metadata_tile", "label": "metadata_label"}
+            new_names = [rename_map.get(c, c) for c in table.column_names]
+            table = table.rename_columns(new_names)
+
+            if len(table):
+                table = table.append_column(
+                    "metadata_object",
+                    pyarrow.array(
+                        [ext_step.split("_")[-1]] * len(table), pyarrow.string()
+                    ),
+                )
+                table = table.append_column(
+                    "metadata_tp",
+                    pyarrow.array([tp] * len(table), pyarrow.uint8()),
+                )
+                data[step_prefix].append(table)
+
+    all_wide_tables = []
+    for k, wide_tables in data.items():
+        if len(wide_tables):
+            all_wide_tables.append(pyarrow.concat_tables(wide_tables))
+
+    if all_wide_tables:
+        profiles = all_wide_tables[0]
+        for table in all_wide_tables[1:]:
+            profiles = profiles.join(
+                table,
+                keys=[f"metadata_{k}" for k in ("tp", "tile", "object", "label")],
+            )
+
+    return profiles
+
+
+def get_step_output(
+    state_data: dict,
+    fetchers: tuple[Callable | str],
+    steps_dir: Path | None = None,
+) -> numpy.ndarray:
+    """Aggregate outputs across timepoints from in-memory state or per-tp .npz files."""
+    combined_outputs = []
+    for fetcher in fetchers:
+        if isinstance(fetcher, str):
+            if fetcher.startswith("from_disk:"):
+                if steps_dir is None:
+                    raise ValueError(
+                        "from_disk fetcher requires steps_dir; pass it through "
+                        "get_step_output(..., steps_dir=...)"
+                    )
+                step_name = fetcher.removeprefix("from_disk:")
+                aggregated_output = _load_per_tp_masks(Path(steps_dir) / step_name)
+            else:
+                # Monotile assumption (mirrored by _load_per_tp_masks for disk path)
+                aggregated_output = [x[0] for x in state_data[fetcher]]
+        elif isinstance(fetcher, Callable):
+            aggregated_output = fetcher(state_data)
+        else:
+            raise Exception(
+                f"Invalid type, expected Callable or string, got {type(fetcher)}"
+            )
+        combined_outputs.append(aggregated_output)
+
+    return numpy.asarray(combined_outputs)
+
+
+def _load_per_tp_masks(step_dir: Path) -> list[numpy.ndarray]:
+    """Read per-tp .npz mask files written by io.write.write_ndarray.
+
+    Two on-disk formats are supported:
+      - baby segmenters: keys ``tile_0``, ``tile_1``, ... (one per tile)
+      - other segmenters: a single key ``arr_0`` holding a stacked
+        (tiles, Y, X) array
+    """
+    files = sorted(step_dir.glob("*.npz"))
+    if not files:
+        raise FileNotFoundError(
+            f"No per-tp .npz files found under {step_dir}; ensure this step "
+            f"is listed in pipeline['save']."
+        )
+    masks = []
+    for f in files:
+        with numpy.load(f) as npz:
+            keys = list(npz.keys())
+            if "tile_0" in keys:
+                masks.append(npz["tile_0"])
+            elif keys == ["arr_0"]:
+                stacked = npz["arr_0"]
+                masks.append(stacked[0])
+            else:
+                raise ValueError(f"Unrecognised .npz layout in {f}: keys={keys}")
+    return masks
+
+
+# ---------------------------------------------------------------------------
+# Builder helper shared by both pipeline builders
+# ---------------------------------------------------------------------------
+
+
+def _attach_trackastra(
+    base_pipeline: dict,
+    channels_to_segment: Sequence[str],
+    trackastra_address: str,
+    trackastra_parameters: dict | None,
+) -> None:
+    """Wire a nahual_trackastra global step into ``base_pipeline`` in place.
+
+    Disk-backed: per-tp segment masks are saved by the main loop, then
+    nahual_trackastra reads them back via the ``from_disk:`` fetcher. This
+    keeps state["data"]["segment_*"] bounded by retain=2 (per-tp tracker
+    needs the last 2 timepoints in RAM).
+    """
+    seg_step_names = [f"segment_{obj}" for obj in channels_to_segment]
+    for seg in seg_step_names:
+        if seg not in base_pipeline["save"]:
+            base_pipeline["save"].append(seg)
+    base_pipeline["save"].append("nahual_trackastra")
+
+    base_pipeline["global_steps"] = {
+        "nahual_trackastra": dict(
+            address=trackastra_address,
+            parameters=trackastra_parameters or {},
+        ),
+    }
+    base_pipeline["global_passed_data"] = {
+        f"nahual_trackastra_{obj}": (f"from_disk:segment_{obj}",)
+        for obj in channels_to_segment
+    }
+
+    retain = base_pipeline.setdefault("retain", {})
+    for seg in seg_step_names:
+        retain.setdefault(seg, 2)
+    retain.setdefault("tile", 1)


### PR DESCRIPTION
This refactor separates the shared pipeline engine from specific segmenter implementations. Shared logic for step initialization, state management, and execution is moved to `pipe_core.py`, while Cellpose and BABY-specific logic are isolated in their own modules.

- Extract shared engine and helper functions to `pipe_core.py`
- Create `pipe_baby.py` and `pipe_builder_baby.py` for BABY
- pipelines Simplify `pipe.py` and `pipe_builder.py` to focus on
- Cellpose Support pipeline-specific post-state hooks for custom
- metadata extraction