### PR TITLE
fix(pipe): widen metadata_tp dtype to uint16 to support >255 time points

### DIFF
--- a/src/aliby/pipe.py
+++ b/src/aliby/pipe.py
@@ -593,7 +593,7 @@ def get_profiles_from_state(state: dict, pipeline: dict) -> pyarrow.Table:
                 )
                 table = table.append_column(
                     "metadata_tp",
-                    pyarrow.array([tp] * len(table), pyarrow.uint8()),
+                    pyarrow.array([tp] * len(table), pyarrow.uint16()),
                 )
                 data[step_prefix].append(table)
 


### PR DESCRIPTION
## Problem

The extract step writes a `metadata_tp` (time-point) column for every row of the profiles parquet, casting the value through `pyarrow.uint8()`. Any time point >=256 overflows the C `uint8` type and aborts the parquet write:

```
File "/work/users/amunoz/projects/aliby-yeast-pipeline/src/aliby/pipe.py", line 596, in get_profiles_from_state
    pyarrow.array([tp] * len(table), pyarrow.uint8()),
  File "pyarrow/array.pxi", line 400, in pyarrow.lib.array
  File "pyarrow/array.pxi", line 46, in pyarrow.lib._sequence_to_array
  File "pyarrow/error.pxi", line 155, in pyarrow.lib.pyarrow_internal_check_status
  File "pyarrow/error.pxi", line 92, in pyarrow.lib.check_status
pyarrow.lib.ArrowInvalid: Value 256 too large to fit in C integer type
```

## Why this hurts

Yeast time-lapses routinely exceed 256 time points. Our Swain-lab corpus is clamped to 270 tps per zarr, so the failure mode is hit on every sufficiently long run. **36 of 388 sites in a recent batch failed on this exact error** (cell-label/trap counts were red herrings; the offending narrow column is the time-point column, not label).

## Fix

Widen `metadata_tp` from `pyarrow.uint8()` (max 255) to `pyarrow.uint16()` (max 65 535). Still narrow enough for parquet column efficiency, but covers any realistic time-lapse length.

No behavioural change for runs with <=255 time points: `uint16` is a strict superset of `uint8`.

## Test plan

- [x] `nix develop --command pytest tests/ -q` before the change: **2238 passed, 7 skipped**
- [x] Same command after the change: **2238 passed, 7 skipped** (no regression)
- [x] `nix fmt` — no diff
- [ ] Validated end-to-end on a >255-tp site from the Swain-lab corpus (will be exercised by the downstream re-run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)