### PR TITLE
fix(pipe_core): align embedder ndarray wrap with strict-zip in format_extraction

### DIFF
--- a/src/aliby/pipe_core.py
+++ b/src/aliby/pipe_core.py
@@ -472,7 +472,12 @@ def get_profiles_from_state(state: dict, pipeline: dict) -> pyarrow.Table:
         step_prefix = ext_step.split("_")[0]
         for tp, ext_output in enumerate(state["data"][ext_step]):
             if isinstance(ext_output, numpy.ndarray):  # arbitrary embedders
-                ext_output = (cycle((("__", "__"),)), (ext_output,))
+                # Wrap a single embedding ndarray as (instructions, metrics)
+                # tuples of equal length so format_extraction's strict-zip
+                # accepts them. format_extraction's ndarray branch (extract.py
+                # lines 563-568) consumes the whole array in one iteration, so
+                # length-1 on both sides is what was logically intended.
+                ext_output = ((("__", "__"),), (ext_output,))
             table: pyarrow.Table = format_extraction(ext_output)
             rename_map = {"tile": "metadata_tile", "label": "metadata_label"}
             new_names = [rename_map.get(c, c) for c in table.column_names]


### PR DESCRIPTION
## Summary

Fixes #19. The arbitrary-embedder branch in `get_profiles_from_state` (`src/aliby/pipe_core.py:475`) wrapped a single embedding ndarray with an infinite `itertools.cycle(...)` paired against a length-1 tuple, which always raised `ValueError: zip() argument 2 is shorter than argument 1` under `format_extraction`'s `zip(..., strict=True)`. This broke every pipeline whose terminal step is `nahual_embed_*`.

## Change

```diff
- ext_output = (cycle((("__", "__"),)), (ext_output,))
+ ext_output = ((("__", "__"),), (ext_output,))
```

`format_extraction`'s ndarray branch (`extract.py:563-568`) consumes the whole array in a single iteration via `np.ndenumerate(metrics)`, so length-1 on both sides is what was logically intended. Added an inline comment explaining the invariant.

## Verification

Applied locally and reran a featurize pipeline (`morphem` model on `jump_lite_updated/jpegxl_lossy_mq.zarr` via Nahual IPC). Workers connect, embedders set up, per-FOV embedding parquets are produced — same flow as pre-refactor.

Closes #19