### PR TITLE
Examples + PR #20 regression test + CI smoke tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,6 +32,28 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: uv sync --all-groups
+      - name: Cache pooch Zenodo dataset
+        # The aliby test dataset (record 19411429, ~18 MB) is fetched once
+        # via pooch and reused by both pytest fixtures and the example
+        # scripts. Caching by the dataset's known hash skips the Zenodo
+        # round-trip on subsequent runs.
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pooch
+          key: pooch-aliby-tests-3a8b1b7b362f002098ba44e65622862057cfe46f0b459514bf270349c8bce4a7
       - name: Test
         run: |
-          pytest tests/ --cov --color=yes --cov-report=xml -s
+          uv run pytest tests/ --cov --color=yes --cov-report=xml -s
+      - name: Smoke-test example scripts
+        # Each example is notebook-style: linear top-to-bottom, defaults to
+        # the bundled Zenodo fixture. Running them here catches drift that
+        # the in-test imports of these modules might miss (the test only
+        # imports them and calls specific helpers; running as __main__
+        # exercises the script's flow end-to-end). Example 02 stubs the
+        # embedder when no Nahual server is available, and example 03
+        # stops after building the pipeline dict, so both complete without
+        # a remote model server.
+        run: |
+          uv run python examples/01_cell_painting_tiff.py
+          uv run python examples/02_zarr_deep_embeddings.py
+          uv run python examples/03_yeast_timelapse_baby.py

--- a/examples/01_cell_painting_tiff.py
+++ b/examples/01_cell_painting_tiff.py
@@ -35,9 +35,9 @@ from aliby.test_data import get_dataset, get_dataset_path
 # at 256x256, one position (well A01, field 1). 516 KB on disk.
 ENTRY = get_dataset("crop_cellpainting_256")
 DATA_PATH = get_dataset_path(ENTRY["name"])
-REGEX = ENTRY["regex"]                  # r".*__([A-Z][0-9]{2})__([0-9])__([A-Za-z]+)\.tif"
+REGEX = ENTRY["regex"]  # r".*__([A-Z][0-9]{2})__([0-9])__([A-Za-z]+)\.tif"
 CAPTURE_ORDER = ENTRY["capture_order"]  # "WFC" -- well, field, channel
-CHANNELS = ENTRY["channels"]            # {"DNA": 0, "ER": 1, "RNA": 2, "AGP": 3, "Mito": 4}
+CHANNELS = ENTRY["channels"]  # {"DNA": 0, "ER": 1, "RNA": 2, "AGP": 3, "Mito": 4}
 
 # ---------------------------------------------------------------------------
 # 2. Discover positions in the dataset.
@@ -139,9 +139,7 @@ if __name__ == "__main__":
     print(f"Writing per-position outputs under {OUTPUT_DIR}")
 
     Parallel(n_jobs=1, backend="loky")(
-        delayed(run_one_position)(
-            base_pipeline, pos, OUTPUT_DIR, NAHUAL_ADDRESSES, i
-        )
+        delayed(run_one_position)(base_pipeline, pos, OUTPUT_DIR, NAHUAL_ADDRESSES, i)
         for i, pos in enumerate(positions)
     )
 
@@ -151,8 +149,10 @@ if __name__ == "__main__":
     profiles_files = sorted((OUTPUT_DIR / "profiles").glob("*.parquet"))
     print(f"Wrote {len(profiles_files)} profiles parquet files.")
     table = pyarrow.parquet.read_table(profiles_files[0])
-    print(f"First profile: {profiles_files[0].name} -- {table.num_rows} rows, "
-          f"{len(table.column_names)} columns")
+    print(
+        f"First profile: {profiles_files[0].name} -- {table.num_rows} rows, "
+        f"{len(table.column_names)} columns"
+    )
     # Expected output on the bundled fixture, approximately:
     #   Wrote 1 profiles parquet files.
     #   First profile: A01__1.parquet -- 26 rows, 632 columns

--- a/examples/01_cell_painting_tiff.py
+++ b/examples/01_cell_painting_tiff.py
@@ -1,0 +1,163 @@
+"""
+Cell Painting profiling: TIFF directory -> cellpose -> cp_measure features.
+
+This example consolidates the pattern used by two downstream applications
+(``afermg/uoe-kenneth-amiodarone`` and an internal GSK-equivalent pipeline).
+Both produce per-cell profiles from multi-channel epifluorescence Cell
+Painting stacks and parallelise per-position with joblib.
+
+Run top-to-bottom. The default input is the small bundled Zenodo fixture
+(``aliby.test_data.get_dataset("crop_cellpainting_256")``) which downloads
+on first use via pooch and caches at ``~/.cache/pooch/aliby_tests/``.
+
+To swap in your own data, replace ``DATA_PATH`` / ``REGEX`` /
+``CAPTURE_ORDER`` below with the TIFF directory + filename convention you
+want to process.
+"""
+
+from copy import deepcopy
+from pathlib import Path
+from tempfile import mkdtemp
+
+import pyarrow.parquet
+from joblib import Parallel, delayed
+
+from aliby.io.dataset import DatasetDir
+from aliby.pipe import run_pipeline_and_post
+from aliby.pipe_builder import build_pipeline_steps
+from aliby.pipe_core import configure_logging
+from aliby.test_data import get_dataset, get_dataset_path
+
+# ---------------------------------------------------------------------------
+# 1. Choose input data and its filename convention.
+# ---------------------------------------------------------------------------
+# The bundled fixture is a 5-channel Cell Painting set (DNA/ER/RNA/AGP/Mito)
+# at 256x256, one position (well A01, field 1). 516 KB on disk.
+ENTRY = get_dataset("crop_cellpainting_256")
+DATA_PATH = get_dataset_path(ENTRY["name"])
+REGEX = ENTRY["regex"]                  # r".*__([A-Z][0-9]{2})__([0-9])__([A-Za-z]+)\.tif"
+CAPTURE_ORDER = ENTRY["capture_order"]  # "WFC" -- well, field, channel
+CHANNELS = ENTRY["channels"]            # {"DNA": 0, "ER": 1, "RNA": 2, "AGP": 3, "Mito": 4}
+
+# ---------------------------------------------------------------------------
+# 2. Discover positions in the dataset.
+# ---------------------------------------------------------------------------
+datasets = DatasetDir(DATA_PATH, regex=REGEX, capture_order=CAPTURE_ORDER)
+positions = datasets.get_position_ids()
+# positions is a list[dict] of {"key": "<well>__<field>", "path": <DATA_PATH>},
+# one entry per (well, field). For the bundled single-position fixture, one
+# entry. For real plates this would be hundreds to thousands.
+print(f"Discovered {len(positions)} positions: {[p['key'] for p in positions]}")
+# Expected: Discovered 1 positions: ['A01__1']
+
+# ---------------------------------------------------------------------------
+# 3. Build the cellpose + cp_measure pipeline definition.
+# ---------------------------------------------------------------------------
+# `build_pipeline_steps` is the public builder for the standard pipeline
+# (cellpose local or `nahual_cellpose` remote when `nahual_addresses=...`).
+# It bundles per-channel sizeshape + intensity extraction plus per-pair
+# colocalisation (extractmulti_*). Skipping edge-pixel intensity measurements
+# (`cp_measure_feature_kwargs={"intensity":{"edge_measurements":False}}`)
+# roughly halves runtime on dense fields.
+NAHUAL_ADDRESSES: list[str] = []  # Set to e.g. ["ipc:///tmp/cellpose0.ipc", ...]
+
+base_pipeline = build_pipeline_steps(
+    channels_to_segment={"nuclei": CHANNELS["DNA"], "cell": CHANNELS["AGP"]},
+    channels_to_extract=list(CHANNELS.values()),
+    features_to_extract=("intensity", "sizeshape"),
+    nahual_addresses=NAHUAL_ADDRESSES or None,
+    cp_measure_feature_kwargs={"intensity": {"edge_measurements": False}},
+)
+# `base_pipeline` is a dict with top-level keys "steps", "passed_data",
+# "passed_methods", "save", "save_interval". `steps` here contains:
+#   tile, segment_nuclei, segment_cell, extract_nuclei, extract_cell,
+#   extractmulti_nuclei, extractmulti_cell
+print("Pipeline steps:", list(base_pipeline["steps"].keys()))
+
+
+# ---------------------------------------------------------------------------
+# 4. Per-position helper -- stamp the pipeline with image_kwargs and run it.
+# ---------------------------------------------------------------------------
+def build_pipeline_for_position(
+    base_pipeline: dict,
+    position: dict,
+    nahual_addresses: list[str],
+    position_index: int,
+    regex: str = REGEX,
+    capture_order: str = CAPTURE_ORDER,
+) -> dict:
+    """Return a deepcopy of ``base_pipeline`` configured for one position."""
+    pipeline = deepcopy(base_pipeline)
+    pipeline["io"] = {
+        "input_path": {"key": position["key"], "path": position["path"]},
+        "capture_order": capture_order,
+    }
+    pipeline["steps"]["tile"]["image_kwargs"] = {
+        "source": {"key": position["key"], "path": position["path"]},
+        "regex": regex,
+        "capture_order": capture_order,
+    }
+    if nahual_addresses:
+        addr = nahual_addresses[position_index % len(nahual_addresses)]
+        for step_name, step_params in pipeline["steps"].items():
+            if step_name.startswith("segment_") and "segmenter_kwargs" in step_params:
+                step_params["segmenter_kwargs"]["address"] = addr
+    return pipeline
+
+
+def run_one_position(
+    base_pipeline: dict,
+    position: dict,
+    output_path: Path,
+    nahual_addresses: list[str],
+    position_index: int,
+    regex: str = REGEX,
+    capture_order: str = CAPTURE_ORDER,
+) -> None:
+    configure_logging(output_path / "log.txt")
+    pipeline = build_pipeline_for_position(
+        base_pipeline,
+        position,
+        nahual_addresses,
+        position_index,
+        regex=regex,
+        capture_order=capture_order,
+    )
+    run_pipeline_and_post(
+        pipeline=pipeline,
+        pipeline_name=position["key"],
+        output_path=output_path,
+        overwrite=False,
+    )
+
+
+if __name__ == "__main__":
+    # -------------------------------------------------------------------
+    # 5. Run all positions in parallel (one joblib worker per position).
+    # -------------------------------------------------------------------
+    OUTPUT_DIR = Path(mkdtemp(prefix="aliby_cellpainting_out_"))
+    print(f"Writing per-position outputs under {OUTPUT_DIR}")
+
+    Parallel(n_jobs=1, backend="loky")(
+        delayed(run_one_position)(
+            base_pipeline, pos, OUTPUT_DIR, NAHUAL_ADDRESSES, i
+        )
+        for i, pos in enumerate(positions)
+    )
+
+    # -------------------------------------------------------------------
+    # 6. Inspect one of the parquet outputs.
+    # -------------------------------------------------------------------
+    profiles_files = sorted((OUTPUT_DIR / "profiles").glob("*.parquet"))
+    print(f"Wrote {len(profiles_files)} profiles parquet files.")
+    table = pyarrow.parquet.read_table(profiles_files[0])
+    print(f"First profile: {profiles_files[0].name} -- {table.num_rows} rows, "
+          f"{len(table.column_names)} columns")
+    # Expected output on the bundled fixture, approximately:
+    #   Wrote 1 profiles parquet files.
+    #   First profile: A01__1.parquet -- 26 rows, 632 columns
+    # Columns include metadata_tile / metadata_label / metadata_object /
+    # metadata_tp plus per-channel cp_measure features like
+    # "0/max/intensity/Intensity_IntegratedIntensity" and pairwise
+    # colocalisation features like "(0, 3)/None/max/pearson".
+    print("Sample columns:", table.column_names[:8], "...")

--- a/examples/02_zarr_deep_embeddings.py
+++ b/examples/02_zarr_deep_embeddings.py
@@ -162,8 +162,10 @@ if __name__ == "__main__":
     )
     embed_step = next(k for k in pipeline["steps"] if k.startswith("nahual_embed_"))
     print(f"Built pipeline with steps: {list(pipeline['steps'])}")
-    print(f"Embed step: {embed_step}  tile_size={MODEL_CONFIG['tile_size']}  "
-          f"selected_channels={MODEL_CONFIG['selected_channels']}")
+    print(
+        f"Embed step: {embed_step}  tile_size={MODEL_CONFIG['tile_size']}  "
+        f"selected_channels={MODEL_CONFIG['selected_channels']}"
+    )
     # Expected: Built pipeline with steps: ['tile', 'nahual_embed_dinov2']
     #           Embed step: nahual_embed_dinov2  tile_size=224  selected_channels=[0, 1, 2]
 
@@ -189,8 +191,10 @@ if __name__ == "__main__":
         stub_embedding = np.arange(12, dtype=np.float32).reshape(3, 4)
         state = {"data": {embed_step: [stub_embedding]}}
         profiles = get_profiles_from_state(state, pipeline)
-        print(f"Stubbed profiles: {profiles.num_rows} rows, "
-              f"columns={profiles.column_names}")
+        print(
+            f"Stubbed profiles: {profiles.num_rows} rows, "
+            f"columns={profiles.column_names}"
+        )
         assert isinstance(profiles, pa.Table) and profiles.num_rows > 0
         # Expected: Stubbed profiles: 3 rows,
         # columns=['tile', 'label', 'X_0', 'X_1', 'X_2', 'X_3',

--- a/examples/02_zarr_deep_embeddings.py
+++ b/examples/02_zarr_deep_embeddings.py
@@ -1,0 +1,197 @@
+"""
+Deep-learning embeddings: monozarr -> nahual_embed_* via Nahual IPC.
+
+This example exercises the ``nahual_embed_*`` (arbitrary-embedder) terminal
+pathway in ``aliby.pipe_core.get_profiles_from_state``. It mirrors the
+publication-side pattern from ``afermg/JUMP_lite`` -- run a foundation-model
+embedder (DINOv2, OpenPhenom, MorphEM, SubCell, ViT, ...) over every tile of
+a monozarr Cell Painting dataset, with the model hosted in a separate
+process and reached over Nahual's pynng IPC.
+
+Default input is the bundled Zenodo Cell Painting monozarr
+(``crop_cellpainting_256.zarr``, 540 KB), downloaded on first use by
+``aliby.test_data``.
+
+End-to-end execution against a real embedder requires a running Nahual
+server (see Section 4 below). When no server is reachable the script stops
+after building the pipeline dict and stubbing an ndarray through
+``get_profiles_from_state`` to demonstrate the PR #20 fix path.
+"""
+
+from copy import deepcopy
+from multiprocessing import Pool
+from pathlib import Path
+from tempfile import mkdtemp
+
+import numpy as np
+import pyarrow as pa
+
+from aliby.io.dataset import dispatch_dataset
+from aliby.pipe import run_pipeline_and_post
+from aliby.pipe_core import configure_logging, get_profiles_from_state
+from aliby.test_data import get_dataset, get_dataset_path
+
+# ---------------------------------------------------------------------------
+# 1. Choose input data.
+# ---------------------------------------------------------------------------
+# The bundled monozarr is the same content as crop_cellpainting_256 but
+# written as a zarr root with one (C=5, Y=256, X=256) group per position.
+ENTRY = get_dataset("crop_cellpainting_256.zarr")
+MONOZARR_PATH = get_dataset_path(ENTRY["name"])
+print(f"Monozarr root: {MONOZARR_PATH}")
+
+dataset = dispatch_dataset(MONOZARR_PATH, is_zarr=True)
+positions = dataset.get_position_ids()
+print(f"Discovered {len(positions)} zarr groups: {[p['key'] for p in positions]}")
+# Expected on the bundled fixture:
+#   Discovered 1 zarr groups: ['source_3__CP_25_all_Phenix1__JCPQC016__A01__1__']
+
+# ---------------------------------------------------------------------------
+# 2. Pick an embedder. Each model is hosted in its own server repo and
+#    bound to a pynng IPC socket. Start one socket per GPU you want to feed.
+# ---------------------------------------------------------------------------
+MODEL_REGISTRY: dict[str, dict] = {
+    "dinov2": {
+        "model_group": "dinov2",
+        "tile_size": 224,
+        "selected_channels": [0, 1, 2],
+        "setup_params": {
+            "repo_or_dir": "facebookresearch/dinov2",
+            "model_name": "dinov2_vits14",
+            "pretrained": True,
+            "device": -1,  # -1 tells the server to round-robin its GPUs
+        },
+        "server": "github:afermg/dinov2",
+    },
+    "openphenom": {
+        "model_group": "vit",
+        "tile_size": 256,
+        "selected_channels": [0, 1, 2, 3, 4],
+        "setup_params": {"model_name": "openphenom", "device": -1},
+        "server": "github:afermg/nahual_vit",
+    },
+    "morphem": {
+        "model_group": "vit",
+        "tile_size": 224,
+        "selected_channels": [0, 1, 2, 3, 4],
+        "setup_params": {"model_name": "morphem", "device": -1},
+        "server": "github:afermg/nahual_vit",
+    },
+    "subcell": {
+        "model_group": "subcell",
+        "tile_size": 448,
+        "selected_channels": [3, 2, 1, 0],
+        "setup_params": {"model_name": "subcell", "device": -1},
+        "server": "github:afermg/SubCellPortable",
+    },
+}
+
+MODEL_NAME = "dinov2"
+MODEL_CONFIG = deepcopy(MODEL_REGISTRY[MODEL_NAME])
+
+# Replace with the address(es) of running Nahual servers. Round-robined
+# across positions. Empty list -> live run is skipped (see Section 5).
+ADDRESSES: list[str] = []  # e.g. ["ipc:///tmp/dinov2_0.ipc", "ipc:///tmp/dinov2_1.ipc"]
+
+
+# ---------------------------------------------------------------------------
+# 3. Per-position pipeline builder.
+# ---------------------------------------------------------------------------
+def build_embed_pipeline(
+    position: dict,
+    address: str,
+    model_config: dict,
+) -> dict:
+    """Tile -> nahual_embed_* pipeline dict for a single zarr position."""
+    step_name = f"nahual_embed_{model_config['model_group']}"
+    embed_params: dict = {
+        "address": address,
+        "model_group": model_config["model_group"],
+        "setup_params": model_config["setup_params"],
+    }
+    if model_config.get("selected_channels") is not None:
+        embed_params["selected_channels"] = model_config["selected_channels"]
+
+    return {
+        "io": {"input_path": position, "capture_order": "CYX"},
+        "ntps": 1,
+        "steps": {
+            "tile": {
+                "kind": "crop",
+                "tile_size": model_config["tile_size"],
+                "calculate_drift": False,
+                "image_kwargs": {"source": position, "capture_order": "CYX"},
+            },
+            step_name: embed_params,
+        },
+        "passed_data": {step_name: [("pixels", "tile", "data")]},
+        "save": (),
+        "save_interval": 1,
+    }
+
+
+def run_one_position(args: tuple) -> None:
+    position, model_config, addresses, output_path, position_index = args
+    address = addresses[position_index % len(addresses)]
+    pipeline = build_embed_pipeline(position, address, model_config)
+    configure_logging(output_path / "log.txt")
+    run_pipeline_and_post(
+        pipeline=pipeline,
+        pipeline_name=position["key"],
+        output_path=output_path,
+        overwrite=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 4. Server-launch hint (run in a separate terminal!).
+# ---------------------------------------------------------------------------
+# Each model lives in its own repository. With Nix (handles CUDA/PyTorch):
+#   nix run github:afermg/dinov2#nahual -- --address ipc:///tmp/dinov2_0.ipc
+# Then set ADDRESSES = ["ipc:///tmp/dinov2_0.ipc"] above and re-run.
+
+# ---------------------------------------------------------------------------
+# 5. Either run the pipeline against the live server, or stub the embedder
+#    output to demonstrate the PR #20 ndarray-branch fix path.
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    pipeline = build_embed_pipeline(
+        positions[0],
+        address=(ADDRESSES[0] if ADDRESSES else "ipc:///tmp/not_a_real_server.ipc"),
+        model_config=MODEL_CONFIG,
+    )
+    embed_step = next(k for k in pipeline["steps"] if k.startswith("nahual_embed_"))
+    print(f"Built pipeline with steps: {list(pipeline['steps'])}")
+    print(f"Embed step: {embed_step}  tile_size={MODEL_CONFIG['tile_size']}  "
+          f"selected_channels={MODEL_CONFIG['selected_channels']}")
+    # Expected: Built pipeline with steps: ['tile', 'nahual_embed_dinov2']
+    #           Embed step: nahual_embed_dinov2  tile_size=224  selected_channels=[0, 1, 2]
+
+    if ADDRESSES:
+        # Live run -- one process per position, round-robined across servers.
+        output_dir = Path(mkdtemp(prefix="aliby_embeddings_out_"))
+        print(f"Writing embeddings under {output_dir}")
+        payloads = [
+            (pos, MODEL_CONFIG, ADDRESSES, output_dir, i)
+            for i, pos in enumerate(positions)
+        ]
+        with Pool(processes=min(len(payloads), len(ADDRESSES))) as pool:
+            pool.map(run_one_position, payloads)
+        # Per-position parquet files in <output_dir>/profiles/. Columns are
+        # X_0 ... X_{D-1} for embedding dimension D (e.g. 384 for dinov2_vits14)
+        # plus metadata_tile / metadata_label / metadata_object / metadata_tp.
+    else:
+        # No live server -- stub an embedding ndarray through the same
+        # `get_profiles_from_state` codepath the live run would hit. This is
+        # exactly the path PR #20 fixes: without the fix, the strict-zip in
+        # `format_extraction` raises ValueError because the instructions side
+        # was wrapped in an infinite `itertools.cycle`.
+        stub_embedding = np.arange(12, dtype=np.float32).reshape(3, 4)
+        state = {"data": {embed_step: [stub_embedding]}}
+        profiles = get_profiles_from_state(state, pipeline)
+        print(f"Stubbed profiles: {profiles.num_rows} rows, "
+              f"columns={profiles.column_names}")
+        assert isinstance(profiles, pa.Table) and profiles.num_rows > 0
+        # Expected: Stubbed profiles: 3 rows,
+        # columns=['tile', 'label', 'X_0', 'X_1', 'X_2', 'X_3',
+        #          'metadata_object', 'metadata_tp']

--- a/examples/03_yeast_timelapse_baby.py
+++ b/examples/03_yeast_timelapse_baby.py
@@ -1,0 +1,170 @@
+"""
+Yeast time-lapse profiling: zarr -> BABY -> intensity/sizeshape + tracking.
+
+This example consolidates the pattern used by ``afermg/aliby_baby_processing``
+to process Zenodo-deposited yeast micro-colony time-lapses with the BABY
+segmenter, run remotely via a Nahual baby-phone server.
+
+Default input is the bundled Zenodo yeast time-series monozarr
+(``crop_timeseries_alcatras_square_same_channels_293.zarr``, ~5.7 MB).
+Each per-position group inside the zarr is itself a TCZYX array; the
+``wrap_zarr_as_group`` helper ensures aliby's ``ImageZarr`` opens it via
+the expected ``(group_path, key)`` shape (mirrors the wrapping
+aliby_baby_processing patches in for Zenodo deposits without a root
+``.zgroup``).
+
+End-to-end execution requires a Nahual baby-phone server (see Section 4).
+When the server isn't reachable the script stops after building the pipeline
+dict and reports its shape.
+"""
+
+import json
+from pathlib import Path
+from tempfile import mkdtemp
+
+import zarr
+
+from aliby.io.dataset import DatasetZarr
+from aliby.pipe_baby import run_pipeline_and_post
+from aliby.pipe_builder_baby import build_pipeline_steps
+from aliby.pipe_core import configure_logging
+from aliby.test_data import get_dataset, get_dataset_path
+
+# ---------------------------------------------------------------------------
+# 1. Choose input data.
+# ---------------------------------------------------------------------------
+# A TCZYX zarr root with one (T, C, Z, Y, X) array per yeast position.
+ENTRY = get_dataset("crop_timeseries_alcatras_square_same_channels_293.zarr")
+ROOT_PATH = get_dataset_path(ENTRY["name"])
+print(f"Zarr root: {ROOT_PATH}")
+
+dataset = DatasetZarr(ROOT_PATH)
+positions = dataset.get_position_ids()
+print(f"Discovered {len(positions)} per-position zarr arrays: "
+      f"{[p['key'] for p in positions]}")
+# Expected: Discovered 2 per-position zarr arrays: ['PDR5_GFP_001', 'PDR5_GFP_002']
+POSITION_PATH = Path(positions[0]["path"]) / positions[0]["key"]
+print(f"Working on: {POSITION_PATH}")
+
+# Each per-position group contains a single ``dataset`` array of shape
+# (T, C, Z, Y, X) uint16. For the fixture: T=4, C=3, Z=3, Y=293, X=293.
+arr_shape = zarr.open(str(POSITION_PATH), mode="r")["dataset"].shape
+print(f"Position array shape: {arr_shape}  (T, C, Z, Y, X)")
+
+
+# ---------------------------------------------------------------------------
+# 2. zarr-v2 group wrapper for arrays that ship without a parent .zgroup.
+# ---------------------------------------------------------------------------
+def wrap_zarr_as_group(zarr_path: Path) -> tuple[Path, str]:
+    """Synthesise a ``.zgroup`` next to the array, return (group_path, key)."""
+    parent = zarr_path.parent
+    zgroup = parent / ".zgroup"
+    if not zgroup.exists():
+        zgroup.write_text(json.dumps({"zarr_format": 2}))
+    return parent, zarr_path.name
+
+
+GROUP_PATH, KEY = wrap_zarr_as_group(POSITION_PATH)
+print(f"Wrapped: group_path={GROUP_PATH}  key={KEY}")
+# Expected: Wrapped: group_path=<ROOT_PATH>  key=PDR5_GFP_001
+
+
+# ---------------------------------------------------------------------------
+# 3. BABY pipeline definition.
+# ---------------------------------------------------------------------------
+# BABY runs in a separate process behind a baby-phone Nahual server.
+# `baby_address` and `baby_modelset` are both required by
+# `pipe_builder_baby.build_pipeline_steps`.
+BABY_ADDRESS = "ipc:///tmp/baby.ipc"               # Replace if your server differs
+BABY_MODELSET = "yeast_alcatras_brightfield_60x_5z"  # See BABY docs for the catalogue
+REF_CHANNEL = 0
+REF_Z = 0
+TILE_SIZE = 117
+NTPS = min(2, arr_shape[0])
+
+# ``parallel=false`` plays nicely with joblib loky at the outer per-site
+# level (matches the override aliby_baby_processing uses).
+BABY_EXTRA_ARGS: list[tuple[str, tuple[str, str]]] = [
+    ("refine_outlines", ("", "true")),
+    ("with_edgemasks", ("", "true")),
+    ("with_masks", ("", "true")),
+    ("assign_mothers", ("", "true")),
+    ("parallel", ("", "false")),
+]
+
+
+def build_pipeline(
+    zarr_path: Path,
+    baby_address: str,
+    baby_modelset: str,
+    ntps: int,
+    tile_size: int = TILE_SIZE,
+    ref_channel: int = REF_CHANNEL,
+    ref_z: int = REF_Z,
+) -> dict:
+    group_path, key = wrap_zarr_as_group(zarr_path)
+    pipeline = build_pipeline_steps(
+        baby_address=baby_address,
+        baby_modelset=baby_modelset,
+        channels_to_segment={"cell": ref_channel},
+        features_to_extract=("intensity", "sizeshape"),
+    )
+    pipeline["ntps"] = ntps
+    pipeline["steps"]["tile"].update(
+        tile_size=tile_size,
+        ref_channel=ref_channel,
+        ref_z=ref_z,
+        image_kwargs={
+            "source": {"path": str(group_path), "key": key},
+            "capture_order": "TCZYX",
+            "dimorder": "TCZYX",
+        },
+    )
+    pipeline["steps"]["segment_cell"]["segmenter_kwargs"]["extra_args"] = BABY_EXTRA_ARGS
+    # pipe_builder_baby leaves passed_methods empty (BABY pulls pixels via
+    # its own tiler). Re-wire the cellpose-style accessor so the segmenter
+    # receives the per-timepoint stack.
+    pipeline["passed_methods"] = {"segment_cell": ("tile", "get_fczyx")}
+    return pipeline
+
+
+# ---------------------------------------------------------------------------
+# 4. Server-launch hint (run in a separate terminal!).
+# ---------------------------------------------------------------------------
+# nix run github:afermg/nahual_baby_phone -- --address ipc:///tmp/baby.ipc
+
+# ---------------------------------------------------------------------------
+# 5. Build the pipeline; run end-to-end only if a baby-phone server is up.
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    pipeline = build_pipeline(
+        POSITION_PATH,
+        baby_address=BABY_ADDRESS,
+        baby_modelset=BABY_MODELSET,
+        ntps=NTPS,
+    )
+    print(f"Pipeline steps: {list(pipeline['steps'])}")
+    print(f"ntps={pipeline['ntps']}  "
+          f"segmenter={pipeline['steps']['segment_cell']['segmenter_kwargs']['kind']}  "
+          f"baby_address={pipeline['steps']['segment_cell']['segmenter_kwargs']['address']}")
+    # Expected:
+    #   Pipeline steps: ['tile', 'segment_cell', 'extract_cell']
+    #   ntps=2  segmenter=nahual_baby  baby_address=ipc:///tmp/baby.ipc
+
+    # The line below is what actually launches BABY -- left commented because
+    # it requires a running nahual_baby_phone server. Uncomment after starting
+    # one (see Section 4).
+    #
+    # output_dir = Path(mkdtemp(prefix="aliby_baby_out_"))
+    # print(f"Writing BABY outputs under {output_dir}")
+    # configure_logging(output_dir / "log.txt")
+    # run_pipeline_and_post(
+    #     pipeline=pipeline,
+    #     pipeline_name=POSITION_PATH.stem,
+    #     output_path=output_dir,
+    #     overwrite=True,
+    # )
+    # Outputs:
+    #   <output_dir>/profiles/<position>.parquet  -- per-cell intensity + sizeshape
+    #   <output_dir>/tracking/<position>_segment_cell.parquet
+    #     -- BABY tracking/lineage (mother-daughter assignments per timepoint)

--- a/examples/03_yeast_timelapse_baby.py
+++ b/examples/03_yeast_timelapse_baby.py
@@ -20,14 +20,11 @@ dict and reports its shape.
 
 import json
 from pathlib import Path
-from tempfile import mkdtemp
 
 import zarr
 
 from aliby.io.dataset import DatasetZarr
-from aliby.pipe_baby import run_pipeline_and_post
 from aliby.pipe_builder_baby import build_pipeline_steps
-from aliby.pipe_core import configure_logging
 from aliby.test_data import get_dataset, get_dataset_path
 
 # ---------------------------------------------------------------------------
@@ -40,8 +37,10 @@ print(f"Zarr root: {ROOT_PATH}")
 
 dataset = DatasetZarr(ROOT_PATH)
 positions = dataset.get_position_ids()
-print(f"Discovered {len(positions)} per-position zarr arrays: "
-      f"{[p['key'] for p in positions]}")
+print(
+    f"Discovered {len(positions)} per-position zarr arrays: "
+    f"{[p['key'] for p in positions]}"
+)
 # Expected: Discovered 2 per-position zarr arrays: ['PDR5_GFP_001', 'PDR5_GFP_002']
 POSITION_PATH = Path(positions[0]["path"]) / positions[0]["key"]
 print(f"Working on: {POSITION_PATH}")
@@ -75,7 +74,7 @@ print(f"Wrapped: group_path={GROUP_PATH}  key={KEY}")
 # BABY runs in a separate process behind a baby-phone Nahual server.
 # `baby_address` and `baby_modelset` are both required by
 # `pipe_builder_baby.build_pipeline_steps`.
-BABY_ADDRESS = "ipc:///tmp/baby.ipc"               # Replace if your server differs
+BABY_ADDRESS = "ipc:///tmp/baby.ipc"  # Replace if your server differs
 BABY_MODELSET = "yeast_alcatras_brightfield_60x_5z"  # See BABY docs for the catalogue
 REF_CHANNEL = 0
 REF_Z = 0
@@ -120,7 +119,9 @@ def build_pipeline(
             "dimorder": "TCZYX",
         },
     )
-    pipeline["steps"]["segment_cell"]["segmenter_kwargs"]["extra_args"] = BABY_EXTRA_ARGS
+    pipeline["steps"]["segment_cell"]["segmenter_kwargs"]["extra_args"] = (
+        BABY_EXTRA_ARGS
+    )
     # pipe_builder_baby leaves passed_methods empty (BABY pulls pixels via
     # its own tiler). Re-wire the cellpose-style accessor so the segmenter
     # receives the per-timepoint stack.
@@ -144,9 +145,11 @@ if __name__ == "__main__":
         ntps=NTPS,
     )
     print(f"Pipeline steps: {list(pipeline['steps'])}")
-    print(f"ntps={pipeline['ntps']}  "
-          f"segmenter={pipeline['steps']['segment_cell']['segmenter_kwargs']['kind']}  "
-          f"baby_address={pipeline['steps']['segment_cell']['segmenter_kwargs']['address']}")
+    print(
+        f"ntps={pipeline['ntps']}  "
+        f"segmenter={pipeline['steps']['segment_cell']['segmenter_kwargs']['kind']}  "
+        f"baby_address={pipeline['steps']['segment_cell']['segmenter_kwargs']['address']}"
+    )
     # Expected:
     #   Pipeline steps: ['tile', 'segment_cell', 'extract_cell']
     #   ntps=2  segmenter=nahual_baby  baby_address=ipc:///tmp/baby.ipc

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,110 @@
+# aliby examples
+
+Notebook-style scripts that exercise each of aliby's main pipeline shapes.
+Each script flows top-to-bottom and defaults to the bundled Zenodo test
+dataset (fetched on first use via pooch, cached under
+`~/.cache/pooch/aliby_tests/`). Swap in your own data by editing the
+`DATA_PATH` / `REGEX` / `CAPTURE_ORDER` (or zarr root) constants at the top.
+
+## Catalogue
+
+| Example | Input modality | Segmenter | Extractor | Bundled fixture | Downstream app it derives from |
+|---|---|---|---|---|---|
+| [`01_cell_painting_tiff.py`](./01_cell_painting_tiff.py) | TIFF directory, multi-channel epifluorescence | `cellpose` (local) or `nahual_cellpose` (remote) | `cp_measure` intensity + sizeshape + colocalisation, joblib per-position | `crop_cellpainting_256` (516 KB) | uoe-kenneth-amiodarone (and the internal GSK pipeline it mirrors) |
+| [`02_zarr_deep_embeddings.py`](./02_zarr_deep_embeddings.py) | Monozarr (CYX groups) | -- (tile only) | `nahual_embed_*` -- DINOv2 / OpenPhenom / MorphEM / SubCell | `crop_cellpainting_256.zarr` (540 KB) | JUMP_lite |
+| [`03_yeast_timelapse_baby.py`](./03_yeast_timelapse_baby.py) | TCZYX zarr (time-lapse) | `nahual_baby` via baby-phone | `cp_measure` intensity + sizeshape; BABY tracking/lineage as a post-step | `crop_timeseries_alcatras_square_same_channels_293.zarr` (5.7 MB) | aliby_baby_processing |
+
+`02_zarr_deep_embeddings.py` is the example that exercises the PR #20 fix
+(`get_profiles_from_state`'s ndarray branch, `pipe_core.py:474-480`).
+Without that patch every embedder pipeline raises
+`ValueError: zip() argument 2 is shorter than argument 1` from
+`format_extraction`'s strict zip. The script stubs an embedding ndarray
+through `get_profiles_from_state` when no live Nahual server is configured,
+so running the script alone is enough to demonstrate the fix.
+
+## Running
+
+```bash
+uv run python examples/01_cell_painting_tiff.py
+uv run python examples/02_zarr_deep_embeddings.py
+uv run python examples/03_yeast_timelapse_baby.py
+```
+
+Examples 02 and 03 need a Nahual model server to actually invoke the
+remote inference path -- the launch hint lives in each script's Section 4.
+Without a server, 02 stubs the embedder output and 03 stops after building
+the pipeline dict, so the script always runs to completion (and prints
+expected outputs as comments).
+
+## Bundled test dataset
+
+The fixture is the same Zenodo deposit (`19411429`) the test suite uses.
+Five sub-datasets totalling ~18 MB cover every modality aliby supports:
+
+| Sub-dataset | Modality | Layout | Used by |
+|---|---|---|---|
+| `crop_cellpainting_256` | Cell Painting TIFF | `DatasetDir`, regex `WFC` | Example 01 + `tests/test_cellpose_cpmeasure_minimal.py` |
+| `crop_cellpainting_256.zarr` | Cell Painting monozarr | `DatasetZarr`, CYX groups | Example 02 |
+| `crop_timeseries_alcatras_round_diff_dims_293` | Yeast time-series TIFF | `DatasetDir`, regex `FTCZ` | `tests/test_cellpose_cpmeasure_minimal.py` |
+| `crop_timeseries_alcatras_square_same_channels_293` | Yeast time-series TIFF | `DatasetDir`, regex `FTCZ` | `tests/test_cellpose_cpmeasure_minimal.py` |
+| `crop_timeseries_alcatras_square_same_channels_293.zarr` | Yeast time-series zarr | `DatasetZarr`, TCZYX | Example 03 |
+
+The catalogue lives at `src/aliby/test_data.py` and exposes:
+
+```python
+from aliby.test_data import DATASETS, get_dataset, get_dataset_path, get_data_root
+```
+
+Use `get_dataset_path("crop_cellpainting_256")` to get the absolute path
+to a sub-dataset (downloads it on first call), and `get_dataset(name)` to
+look up the regex / capture order / channel-name → index mapping. Tests
+share the same module via the `data_dir` fixture in `tests/conftest.py`.
+
+## Downstream cross-check
+
+The four downstream applications below consume aliby in production. They
+form the regression target for API-surface changes: any aliby release
+should preserve the symbols and signatures they import.
+
+| App | Repo (visibility) | aliby symbols imported | Module split | Tested against current `main`? |
+|---|---|---|---|---|
+| Cell Painting profiling (UoE/Kenneth) | `afermg/uoe-kenneth-amiodarone` (public) | `aliby.io.dataset.DatasetDir`, `aliby.pipe.run_pipeline_and_post`, `aliby.pipe_builder.build_pipeline_steps`, `aliby.pipe_core.configure_logging` | `pipe` (cellpose flavour) | Yes -- unaffected by PR #20 |
+| Cell Painting profiling (GSK) | `afermg/gsk-ia` (private/404 from public gh) | same as uoe-kenneth (per uoe-kenneth's `CLAUDE.md`: "Mirrors the GSK standardize pipeline") | `pipe` | Inferred green via uoe-kenneth |
+| Deep-learning featurisation | `afermg/JUMP_lite` `main` (public) | `aliby.io.dataset.dispatch_dataset`, `aliby.pipe.run_pipeline_and_post` | `pipe` + `nahual_embed_*` | Sensitive to PR #20 (broken without it). **Additional API drift**: JUMP_lite still calls `run_pipeline_and_post(img_source=..., fov=...)` which current aliby does not accept -- the signature is `(pipeline, pipeline_name, output_path, overwrite)`. Needs a downstream-side update beyond PR #20. |
+| Yeast time-lapse | `afermg/aliby_baby_processing` (public) | `aliby.pipe_builder_baby.build_pipeline_steps`, `aliby.pipe_baby.run_pipeline_and_post` | `pipe_baby` (BABY flavour) | Yes -- unaffected by PR #20 |
+
+The `JUMP_lite#3` PR pivots away from aliby featurisation entirely (it
+uses saturation YAML pipelines) and is out of scope for this validation.
+
+### How to re-run the cross-check
+
+For each downstream repo, after pulling the latest aliby:
+
+```bash
+# 1. The aliby symbols the app imports must all still exist:
+grep -RhE '^(from aliby|import aliby)' <downstream-repo>/ | sort -u
+# 2. The entry-point signature each app uses must match current aliby:
+grep -RnE '(build_pipeline_steps|run_pipeline_and_post)\(' <downstream-repo>/
+```
+
+Diff against the symbols / signatures in this table and the per-example
+imports. Any drift here is a downstream-update task for the app's owner.
+
+## Anonymisation
+
+These examples were derived from production scripts that carried proprietary
+identifiers (paths under `/datastore/alan/...`, ELN IDs, plate codes,
+internal QC blacklists). The example versions use placeholder constants
+only and document the expected layout in each script's header docstring.
+The bundled Zenodo fixture (record `19411429`) was published by the aliby
+maintainers and is already a publicly-cleared subset (the Cell Painting
+crops are derived from a public JUMP Consortium QC plate, not from any
+private GSK or UoE dataset).
+
+If you add a new example, verify before committing:
+
+```bash
+grep -rE '(ELN[0-9]+|H00[A-Z0-9_]+|/datastore/alan/)' examples/*.py
+```
+
+The above must return no matches.

--- a/examples/README.md
+++ b/examples/README.md
@@ -8,11 +8,11 @@ dataset (fetched on first use via pooch, cached under
 
 ## Catalogue
 
-| Example | Input modality | Segmenter | Extractor | Bundled fixture | Downstream app it derives from |
-|---|---|---|---|---|---|
-| [`01_cell_painting_tiff.py`](./01_cell_painting_tiff.py) | TIFF directory, multi-channel epifluorescence | `cellpose` (local) or `nahual_cellpose` (remote) | `cp_measure` intensity + sizeshape + colocalisation, joblib per-position | `crop_cellpainting_256` (516 KB) | uoe-kenneth-amiodarone (and the internal GSK pipeline it mirrors) |
-| [`02_zarr_deep_embeddings.py`](./02_zarr_deep_embeddings.py) | Monozarr (CYX groups) | -- (tile only) | `nahual_embed_*` -- DINOv2 / OpenPhenom / MorphEM / SubCell | `crop_cellpainting_256.zarr` (540 KB) | JUMP_lite |
-| [`03_yeast_timelapse_baby.py`](./03_yeast_timelapse_baby.py) | TCZYX zarr (time-lapse) | `nahual_baby` via baby-phone | `cp_measure` intensity + sizeshape; BABY tracking/lineage as a post-step | `crop_timeseries_alcatras_square_same_channels_293.zarr` (5.7 MB) | aliby_baby_processing |
+| Example                                                      | Input modality                                | Segmenter                                        | Extractor                                                                | Bundled fixture                                                   | Downstream app it derives from                                    |
+| ------------------------------------------------------------ | --------------------------------------------- | ------------------------------------------------ | ------------------------------------------------------------------------ | ----------------------------------------------------------------- | ----------------------------------------------------------------- |
+| [`01_cell_painting_tiff.py`](./01_cell_painting_tiff.py)     | TIFF directory, multi-channel epifluorescence | `cellpose` (local) or `nahual_cellpose` (remote) | `cp_measure` intensity + sizeshape + colocalisation, joblib per-position | `crop_cellpainting_256` (516 KB)                                  | uoe-kenneth-amiodarone (and the internal GSK pipeline it mirrors) |
+| [`02_zarr_deep_embeddings.py`](./02_zarr_deep_embeddings.py) | Monozarr (CYX groups)                         | -- (tile only)                                   | `nahual_embed_*` -- DINOv2 / OpenPhenom / MorphEM / SubCell              | `crop_cellpainting_256.zarr` (540 KB)                             | JUMP_lite                                                         |
+| [`03_yeast_timelapse_baby.py`](./03_yeast_timelapse_baby.py) | TCZYX zarr (time-lapse)                       | `nahual_baby` via baby-phone                     | `cp_measure` intensity + sizeshape; BABY tracking/lineage as a post-step | `crop_timeseries_alcatras_square_same_channels_293.zarr` (5.7 MB) | aliby_baby_processing                                             |
 
 `02_zarr_deep_embeddings.py` is the example that exercises the PR #20 fix
 (`get_profiles_from_state`'s ndarray branch, `pipe_core.py:474-480`).
@@ -41,13 +41,13 @@ expected outputs as comments).
 The fixture is the same Zenodo deposit (`19411429`) the test suite uses.
 Five sub-datasets totalling ~18 MB cover every modality aliby supports:
 
-| Sub-dataset | Modality | Layout | Used by |
-|---|---|---|---|
-| `crop_cellpainting_256` | Cell Painting TIFF | `DatasetDir`, regex `WFC` | Example 01 + `tests/test_cellpose_cpmeasure_minimal.py` |
-| `crop_cellpainting_256.zarr` | Cell Painting monozarr | `DatasetZarr`, CYX groups | Example 02 |
-| `crop_timeseries_alcatras_round_diff_dims_293` | Yeast time-series TIFF | `DatasetDir`, regex `FTCZ` | `tests/test_cellpose_cpmeasure_minimal.py` |
-| `crop_timeseries_alcatras_square_same_channels_293` | Yeast time-series TIFF | `DatasetDir`, regex `FTCZ` | `tests/test_cellpose_cpmeasure_minimal.py` |
-| `crop_timeseries_alcatras_square_same_channels_293.zarr` | Yeast time-series zarr | `DatasetZarr`, TCZYX | Example 03 |
+| Sub-dataset                                              | Modality               | Layout                     | Used by                                                 |
+| -------------------------------------------------------- | ---------------------- | -------------------------- | ------------------------------------------------------- |
+| `crop_cellpainting_256`                                  | Cell Painting TIFF     | `DatasetDir`, regex `WFC`  | Example 01 + `tests/test_cellpose_cpmeasure_minimal.py` |
+| `crop_cellpainting_256.zarr`                             | Cell Painting monozarr | `DatasetZarr`, CYX groups  | Example 02                                              |
+| `crop_timeseries_alcatras_round_diff_dims_293`           | Yeast time-series TIFF | `DatasetDir`, regex `FTCZ` | `tests/test_cellpose_cpmeasure_minimal.py`              |
+| `crop_timeseries_alcatras_square_same_channels_293`      | Yeast time-series TIFF | `DatasetDir`, regex `FTCZ` | `tests/test_cellpose_cpmeasure_minimal.py`              |
+| `crop_timeseries_alcatras_square_same_channels_293.zarr` | Yeast time-series zarr | `DatasetZarr`, TCZYX       | Example 03                                              |
 
 The catalogue lives at `src/aliby/test_data.py` and exposes:
 
@@ -66,12 +66,12 @@ The four downstream applications below consume aliby in production. They
 form the regression target for API-surface changes: any aliby release
 should preserve the symbols and signatures they import.
 
-| App | Repo (visibility) | aliby symbols imported | Module split | Tested against current `main`? |
-|---|---|---|---|---|
-| Cell Painting profiling (UoE/Kenneth) | `afermg/uoe-kenneth-amiodarone` (public) | `aliby.io.dataset.DatasetDir`, `aliby.pipe.run_pipeline_and_post`, `aliby.pipe_builder.build_pipeline_steps`, `aliby.pipe_core.configure_logging` | `pipe` (cellpose flavour) | Yes -- unaffected by PR #20 |
-| Cell Painting profiling (GSK) | `afermg/gsk-ia` (private/404 from public gh) | same as uoe-kenneth (per uoe-kenneth's `CLAUDE.md`: "Mirrors the GSK standardize pipeline") | `pipe` | Inferred green via uoe-kenneth |
-| Deep-learning featurisation | `afermg/JUMP_lite` `main` (public) | `aliby.io.dataset.dispatch_dataset`, `aliby.pipe.run_pipeline_and_post` | `pipe` + `nahual_embed_*` | Sensitive to PR #20 (broken without it). **Additional API drift**: JUMP_lite still calls `run_pipeline_and_post(img_source=..., fov=...)` which current aliby does not accept -- the signature is `(pipeline, pipeline_name, output_path, overwrite)`. Needs a downstream-side update beyond PR #20. |
-| Yeast time-lapse | `afermg/aliby_baby_processing` (public) | `aliby.pipe_builder_baby.build_pipeline_steps`, `aliby.pipe_baby.run_pipeline_and_post` | `pipe_baby` (BABY flavour) | Yes -- unaffected by PR #20 |
+| App                                   | Repo (visibility)                            | aliby symbols imported                                                                                                                            | Module split               | Tested against current `main`?                                                                                                                                                                                                                                                                       |
+| ------------------------------------- | -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Cell Painting profiling (UoE/Kenneth) | `afermg/uoe-kenneth-amiodarone` (public)     | `aliby.io.dataset.DatasetDir`, `aliby.pipe.run_pipeline_and_post`, `aliby.pipe_builder.build_pipeline_steps`, `aliby.pipe_core.configure_logging` | `pipe` (cellpose flavour)  | Yes -- unaffected by PR #20                                                                                                                                                                                                                                                                          |
+| Cell Painting profiling (GSK)         | `afermg/gsk-ia` (private/404 from public gh) | same as uoe-kenneth (per uoe-kenneth's `CLAUDE.md`: "Mirrors the GSK standardize pipeline")                                                       | `pipe`                     | Inferred green via uoe-kenneth                                                                                                                                                                                                                                                                       |
+| Deep-learning featurisation           | `afermg/JUMP_lite` `main` (public)           | `aliby.io.dataset.dispatch_dataset`, `aliby.pipe.run_pipeline_and_post`                                                                           | `pipe` + `nahual_embed_*`  | Sensitive to PR #20 (broken without it). **Additional API drift**: JUMP_lite still calls `run_pipeline_and_post(img_source=..., fov=...)` which current aliby does not accept -- the signature is `(pipeline, pipeline_name, output_path, overwrite)`. Needs a downstream-side update beyond PR #20. |
+| Yeast time-lapse                      | `afermg/aliby_baby_processing` (public)      | `aliby.pipe_builder_baby.build_pipeline_steps`, `aliby.pipe_baby.run_pipeline_and_post`                                                           | `pipe_baby` (BABY flavour) | Yes -- unaffected by PR #20                                                                                                                                                                                                                                                                          |
 
 The `JUMP_lite#3` PR pivots away from aliby featurisation entirely (it
 uses saturation YAML pipelines) and is out of scope for this validation.

--- a/src/aliby/pipe_core.py
+++ b/src/aliby/pipe_core.py
@@ -472,7 +472,12 @@ def get_profiles_from_state(state: dict, pipeline: dict) -> pyarrow.Table:
         step_prefix = ext_step.split("_")[0]
         for tp, ext_output in enumerate(state["data"][ext_step]):
             if isinstance(ext_output, numpy.ndarray):  # arbitrary embedders
-                ext_output = (cycle((("__", "__"),)), (ext_output,))
+                # Wrap a single embedding ndarray as (instructions, metrics)
+                # tuples of equal length so format_extraction's strict-zip
+                # accepts them. format_extraction's ndarray branch (extract.py
+                # lines 563-568) consumes the whole array in one iteration, so
+                # length-1 on both sides is what was logically intended.
+                ext_output = ((("__", "__"),), (ext_output,))
             table: pyarrow.Table = format_extraction(ext_output)
             rename_map = {"tile": "metadata_tile", "label": "metadata_label"}
             new_names = [rename_map.get(c, c) for c in table.column_names]

--- a/src/aliby/test_data.py
+++ b/src/aliby/test_data.py
@@ -1,0 +1,161 @@
+"""
+Shared test-data loader for aliby tests, examples, and notebooks.
+
+A small public dataset hosted on Zenodo (record 19411429) covers every
+input modality aliby supports: TIFF directories (single-timepoint Cell
+Painting and multi-timepoint yeast), per-position zarr v3 groups (CYX for
+Cell Painting, TCZYX for time-series), and the matching FTCZ filename
+convention. The dataset is fetched once on first use via pooch and cached
+under ``~/.cache/pooch/aliby_tests/``.
+
+Public API
+----------
+- :data:`DATASETS` -- list of catalogue entries, one per sub-dataset.
+- :func:`get_data_root` -- absolute path to the unpacked dataset root.
+- :func:`get_dataset` -- look up a single catalogue entry by name.
+- :func:`get_dataset_path` -- absolute path to a sub-dataset.
+
+Catalogue entry schema
+----------------------
+- ``name`` -- subdirectory name under the dataset root.
+- ``modality`` -- "cell_painting", "yeast_timelapse", or
+  "cell_painting_zarr"/"yeast_timelapse_zarr" for the zarr variants.
+- ``layout`` -- "tiff_dir" or "zarr".
+- ``regex`` / ``capture_order`` -- aliby ``DatasetDir`` arguments
+  (TIFF datasets only; ``None`` for zarr).
+- ``channels`` -- channel-name → index mapping, when applicable.
+- ``description`` -- human-readable summary.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ZENODO_URL = (
+    "https://zenodo.org/api/records/19411429/files/"
+    "aliby_test_dataset.tar.gz/content"
+)
+ZENODO_HASH = "3a8b1b7b362f002098ba44e65622862057cfe46f0b459514bf270349c8bce4a7"
+DOWNLOAD_NAME = "aliby_test_dataset.tar.gz"
+EXTRACT_DIR = "aliby_tests"
+LEGACY_LOCAL_ROOT = Path("/datastore/alan/aliby/test_dataset/data/")
+
+
+DATASETS: list[dict] = [
+    {
+        "name": "crop_cellpainting_256",
+        "modality": "cell_painting",
+        "layout": "tiff_dir",
+        "regex": r".*__([A-Z][0-9]{2})__([0-9])__([A-Za-z]+)\.tif",
+        "capture_order": "WFC",
+        "channels": {"DNA": 0, "ER": 1, "RNA": 2, "AGP": 3, "Mito": 4},
+        "description": (
+            "5-channel Cell Painting (DNA/ER/RNA/AGP/Mito), single-timepoint, "
+            "256x256 crops. Standard pattern for the cellpose + cp_measure pipeline."
+        ),
+    },
+    {
+        "name": "crop_cellpainting_256.zarr",
+        "modality": "cell_painting_zarr",
+        "layout": "zarr",
+        "regex": None,
+        "capture_order": "CYX",
+        "channels": {"DNA": 0, "ER": 1, "RNA": 2, "AGP": 3, "Mito": 4},
+        "description": (
+            "Same crops as crop_cellpainting_256 written as a zarr root with "
+            "one (5, Y, X) group per position. Drives the deep-embeddings "
+            "(nahual_embed_*) example."
+        ),
+    },
+    {
+        "name": "crop_timeseries_alcatras_round_diff_dims_293",
+        "modality": "yeast_timelapse",
+        "layout": "tiff_dir",
+        "regex": r".*/([^/]+)/.+_([0-9]{6})_([A-Za-z0-9]+)_(?:.*_)?([0-9]+)\.tif",
+        "capture_order": "FTCZ",
+        "channels": None,
+        "description": (
+            "Yeast time-series in round alcatras traps, per-position TIFF "
+            "subdirectories, three channels with z-stacks of varying dimensions."
+        ),
+    },
+    {
+        "name": "crop_timeseries_alcatras_square_same_channels_293",
+        "modality": "yeast_timelapse",
+        "layout": "tiff_dir",
+        "regex": r".*/([^/]+)/.+_([0-9]{6})_([A-Za-z0-9]+)_(?:.*_)?([0-9]+)\.tif",
+        "capture_order": "FTCZ",
+        "channels": None,
+        "description": (
+            "Yeast time-series in square alcatras traps, per-position TIFF "
+            "subdirectories. Same channel shape across positions."
+        ),
+    },
+    {
+        "name": "crop_timeseries_alcatras_square_same_channels_293.zarr",
+        "modality": "yeast_timelapse_zarr",
+        "layout": "zarr",
+        "regex": None,
+        "capture_order": "TCZYX",
+        "channels": None,
+        "description": (
+            "Same content as the square-traps TIFF dataset, written as a zarr "
+            "root with one (T, C, Z, Y, X) array per position. Drives the "
+            "BABY time-lapse example without a .zgroup wrapper step."
+        ),
+    },
+]
+
+
+def _build_pooch_call() -> tuple[str, str, str, object]:
+    """Return arguments for ``pooch.retrieve`` without importing pooch eagerly."""
+    import pooch
+
+    return (
+        ZENODO_URL,
+        ZENODO_HASH,
+        DOWNLOAD_NAME,
+        pooch.Untar(extract_dir=EXTRACT_DIR),
+    )
+
+
+def get_data_root() -> Path:
+    """Return the absolute path to the unpacked dataset root.
+
+    Honours the legacy on-disk copy at :data:`LEGACY_LOCAL_ROOT` when
+    present (e.g. on the maintainer's workstation). Otherwise fetches the
+    Zenodo tarball via pooch on first call and reuses the cache thereafter.
+    """
+    if LEGACY_LOCAL_ROOT.exists():
+        return LEGACY_LOCAL_ROOT
+
+    try:
+        import pooch
+    except ImportError as e:
+        raise ImportError(
+            "aliby.test_data requires `pooch` to download the Zenodo "
+            "dataset. Install with `uv add pooch` or `pip install pooch`."
+        ) from e
+
+    url, known_hash, fname, processor = _build_pooch_call()
+    files = pooch.retrieve(
+        url=url,
+        known_hash=known_hash,
+        fname=fname,
+        processor=processor,
+    )
+    return Path(files[0].split(EXTRACT_DIR + "/")[0]) / EXTRACT_DIR
+
+
+def get_dataset(name: str) -> dict:
+    """Look up a catalogue entry by ``name``."""
+    for entry in DATASETS:
+        if entry["name"] == name:
+            return entry
+    valid = ", ".join(d["name"] for d in DATASETS)
+    raise KeyError(f"Unknown dataset {name!r}. Valid names: {valid}")
+
+
+def get_dataset_path(name: str) -> Path:
+    """Return the absolute path to a sub-dataset, fetching it if needed."""
+    return get_data_root() / name

--- a/src/aliby/test_data.py
+++ b/src/aliby/test_data.py
@@ -32,8 +32,7 @@ from __future__ import annotations
 from pathlib import Path
 
 ZENODO_URL = (
-    "https://zenodo.org/api/records/19411429/files/"
-    "aliby_test_dataset.tar.gz/content"
+    "https://zenodo.org/api/records/19411429/files/aliby_test_dataset.tar.gz/content"
 )
 ZENODO_HASH = "3a8b1b7b362f002098ba44e65622862057cfe46f0b459514bf270349c8bce4a7"
 DOWNLOAD_NAME = "aliby_test_dataset.tar.gz"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,18 +1,15 @@
 import pytest
-from pathlib import Path
-import pooch
+
+from aliby.test_data import get_data_root
 
 
 @pytest.fixture(scope="session")
 def data_dir():
-    data_path = Path("/datastore/alan/aliby/test_dataset/data/")
-    if not data_path.exists():
-        marker = "aliby_tests/"
-        files = pooch.retrieve(
-            url="https://zenodo.org/api/records/19411429/files/aliby_test_dataset.tar.gz/content",
-            known_hash="3a8b1b7b362f002098ba44e65622862057cfe46f0b459514bf270349c8bce4a7",
-            fname="aliby_test_dataset.tar.gz",
-            processor=pooch.Untar(extract_dir="aliby_tests"),
-        )
-        data_path = Path(files[0].split(marker)[0] + marker)
-    return data_path
+    """Path to the unpacked aliby test dataset (Zenodo record 19411429).
+
+    Resolved by :func:`aliby.test_data.get_data_root` -- uses the legacy
+    on-disk copy at ``/datastore/alan/aliby/test_dataset/data/`` when
+    present, otherwise fetches from Zenodo via pooch and caches under
+    ``~/.cache/pooch/aliby_tests/``.
+    """
+    return get_data_root()

--- a/tests/test_examples_with_fixture.py
+++ b/tests/test_examples_with_fixture.py
@@ -152,5 +152,7 @@ def test_example_03_yeast_timelapse_baby_pipeline_shape(tmp_path):
     )
     assert pipeline["ntps"] == 2
     assert "segment_cell" in pipeline["steps"]
-    assert pipeline["steps"]["segment_cell"]["segmenter_kwargs"]["kind"] == "nahual_baby"
+    assert (
+        pipeline["steps"]["segment_cell"]["segmenter_kwargs"]["kind"] == "nahual_baby"
+    )
     assert pipeline["passed_methods"] == {"segment_cell": ("tile", "get_fczyx")}

--- a/tests/test_examples_with_fixture.py
+++ b/tests/test_examples_with_fixture.py
@@ -1,0 +1,156 @@
+"""
+End-to-end coverage for the three published examples against the shared
+pooch-fetched Zenodo test dataset.
+
+Each test exercises one example script's pipeline shape (without invoking
+its CLI) so the published examples are pinned against the canonical test
+data. The nahual_embed example only exercises the ndarray-branch wiring in
+``get_profiles_from_state`` -- a live Nahual embedder server is not started.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import numpy as np
+import pyarrow as pa
+import pytest
+
+from aliby.io.dataset import DatasetDir, DatasetZarr, dispatch_dataset
+from aliby.pipe import run_pipeline_and_post
+from aliby.pipe_builder import build_pipeline_steps
+from aliby.pipe_core import get_profiles_from_state
+from aliby.test_data import get_dataset, get_dataset_path
+
+EXAMPLES_DIR = Path(__file__).resolve().parent.parent / "examples"
+
+
+def _import_example(stem: str):
+    """Load an example module by stem so its helpers are reusable here."""
+    path = EXAMPLES_DIR / f"{stem}.py"
+    spec = importlib.util.spec_from_file_location(stem, path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[stem] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_example_01_cell_painting_tiff(tmp_path):
+    """01_cell_painting_tiff: TIFF dir -> cellpose -> cp_measure."""
+    entry = get_dataset("crop_cellpainting_256")
+    path = get_dataset_path(entry["name"])
+    if not path.exists():
+        pytest.skip(f"Test dataset not present: {path}")
+
+    example = _import_example("01_cell_painting_tiff")
+
+    datasets = DatasetDir(
+        path, regex=entry["regex"], capture_order=entry["capture_order"]
+    )
+    positions = datasets.get_position_ids()
+    assert positions, f"No positions discovered in {path}"
+
+    base_pipeline = build_pipeline_steps(
+        channels_to_segment={"nuclei": entry["channels"]["DNA"]},
+        channels_to_extract=[entry["channels"]["DNA"]],
+        features_to_extract=("intensity", "sizeshape"),
+    )
+    pipeline = example.build_pipeline_for_position(
+        base_pipeline,
+        positions[0],
+        nahual_addresses=[],
+        position_index=0,
+    )
+    run_pipeline_and_post(
+        pipeline=pipeline,
+        pipeline_name=positions[0]["key"],
+        output_path=tmp_path,
+        overwrite=True,
+    )
+
+    profiles = tmp_path / "profiles" / f"{positions[0]['key']}.parquet"
+    assert profiles.exists() and profiles.stat().st_size > 0
+
+
+def test_example_02_zarr_deep_embeddings_pipeline_shape(tmp_path):
+    """02_zarr_deep_embeddings: pipeline dict is well-formed and the
+    nahual_embed terminal pathway accepts a stub embedding without an
+    actual remote.
+
+    The end-to-end run requires a Nahual model server. Here we build the
+    pipeline dict against the real monozarr fixture and verify the PR #20
+    fix path by feeding a stub ndarray into ``get_profiles_from_state``."""
+    entry = get_dataset("crop_cellpainting_256.zarr")
+    path = get_dataset_path(entry["name"])
+    if not path.exists():
+        pytest.skip(f"Test dataset not present: {path}")
+
+    example = _import_example("02_zarr_deep_embeddings")
+
+    dataset = dispatch_dataset(path, is_zarr=True)
+    positions = dataset.get_position_ids()
+    assert positions, f"No zarr groups under {path}"
+
+    model_config = example.MODEL_REGISTRY["dinov2"]
+    pipeline = example.build_embed_pipeline(
+        positions[0],
+        address="ipc:///tmp/not_a_real_server.ipc",
+        model_config=model_config,
+    )
+
+    assert "tile" in pipeline["steps"]
+    embed_steps = [k for k in pipeline["steps"] if k.startswith("nahual_embed_")]
+    assert len(embed_steps) == 1
+    assert pipeline["steps"][embed_steps[0]]["model_group"] == "dinov2"
+    assert pipeline["passed_data"][embed_steps[0]] == [("pixels", "tile", "data")]
+
+    # PR #20 regression check on the resulting ndarray contract: the embed
+    # step's output is wrapped by get_profiles_from_state into a length-1
+    # instructions / length-1 metrics tuple before reaching format_extraction.
+    stub_embedding = np.arange(12, dtype=np.float32).reshape(3, 4)
+    state = {"data": {embed_steps[0]: [stub_embedding]}}
+    profiles = get_profiles_from_state(state, pipeline)
+    assert isinstance(profiles, pa.Table)
+    assert profiles.num_rows > 0
+
+
+def test_example_03_yeast_timelapse_baby_pipeline_shape(tmp_path):
+    """03_yeast_timelapse_baby: build_pipeline shape and zgroup wrapper
+    work against the real yeast time-series zarr.
+
+    The end-to-end BABY run requires a baby-phone server; here we exercise
+    the example's :func:`wrap_zarr_as_group` helper and confirm the
+    pipeline dict carries the BABY-specific steps and passed_methods.
+    """
+    entry = get_dataset("crop_timeseries_alcatras_square_same_channels_293.zarr")
+    root = get_dataset_path(entry["name"])
+    if not root.exists():
+        pytest.skip(f"Test dataset not present: {root}")
+
+    example = _import_example("03_yeast_timelapse_baby")
+
+    # Pick the first per-position group inside the zarr root.
+    dataset = DatasetZarr(root)
+    positions = dataset.get_position_ids()
+    assert positions, f"No zarr groups under {root}"
+    pos_path = Path(positions[0]["path"]) / positions[0]["key"]
+
+    group_path, key = example.wrap_zarr_as_group(pos_path)
+    assert (group_path / ".zgroup").exists()
+    assert key == pos_path.name
+
+    pipeline = example.build_pipeline(
+        pos_path,
+        baby_address="ipc:///tmp/not_a_real_baby.ipc",
+        baby_modelset="placeholder_modelset",
+        ntps=2,
+        tile_size=128,
+        ref_channel=0,
+        ref_z=0,
+    )
+    assert pipeline["ntps"] == 2
+    assert "segment_cell" in pipeline["steps"]
+    assert pipeline["steps"]["segment_cell"]["segmenter_kwargs"]["kind"] == "nahual_baby"
+    assert pipeline["passed_methods"] == {"segment_cell": ("tile", "get_fczyx")}

--- a/tests/test_nahual_embed_minimal.py
+++ b/tests/test_nahual_embed_minimal.py
@@ -1,0 +1,101 @@
+"""
+Regression coverage for the `nahual_embed_*` (arbitrary embedder) terminal
+pathway in `get_profiles_from_state`.
+
+A 2-month-old regression (introduced in commit 005622a, the two-pipelines
+refactor) wrapped the embedder ndarray output as
+`(itertools.cycle((("__", "__"),)), (ext_output,))`. Combined with
+`format_extraction`'s `zip(*instructions_result, strict=True)`, the infinite
+`cycle` iterator made the strict zip raise `ValueError: zip() argument 2 is
+shorter than argument 1`, breaking *every* DL-embedding pipeline (DINOv2,
+SubCell, MorphEM, OpenPhenom, ViT, ...).
+
+The fix wraps the ndarray as a length-1 instructions tuple plus a length-1
+metrics tuple so the strict zip yields exactly one (inst, metrics) pair —
+the ndarray branch in `format_extraction` then consumes the entire array
+via `np.ndenumerate` in that single iteration.
+
+These tests pin both halves of the contract:
+
+1. `format_extraction` accepts a length-1 instructions / length-1 metrics
+   payload where the single metrics entry is a 2-D ndarray, and produces
+   one row per ndarray row with one column per ndarray column.
+2. `get_profiles_from_state` wraps a raw ndarray emitted by a `nahual_embed`
+   step into that same shape and yields a non-empty profiles table.
+"""
+
+import numpy as np
+import pyarrow as pa
+import pytest
+
+from aliby.pipe_core import get_profiles_from_state
+from extraction.extract import format_extraction
+
+
+def test_format_extraction_accepts_single_ndarray_payload():
+    """The ndarray branch consumes the whole array in one zip iteration."""
+    embedding = np.arange(12, dtype=np.float32).reshape(3, 4)
+    # Shape produced by the fixed `get_profiles_from_state`: length-1 on
+    # both sides so strict-zip yields exactly one pair.
+    payload = ((("__", "__"),), (embedding,))
+
+    table = format_extraction(payload)
+
+    assert isinstance(table, pa.Table)
+    # `np.ndenumerate` over a 3x4 array yields 12 entries, all rolled up
+    # into the same (tile=0, label=0) row via pivoting.
+    assert table.num_rows == 3
+    metric_columns = [c for c in table.column_names if c.startswith("X_")]
+    assert len(metric_columns) == 4
+    assert set(table.column_names) >= {"tile", "label"} | set(metric_columns)
+
+
+def test_format_extraction_rejects_cycle_payload():
+    """An infinite `cycle` on the instructions side must NOT be accepted.
+
+    This is the exact shape the buggy code produced. We pin the failure so
+    a regression that re-introduces the cycle wrapper is caught here.
+    """
+    from itertools import cycle
+
+    embedding = np.arange(6, dtype=np.float32).reshape(2, 3)
+    bad_payload = (cycle((("__", "__"),)), (embedding,))
+
+    with pytest.raises(ValueError, match="zip"):
+        format_extraction(bad_payload)
+
+
+def test_get_profiles_from_state_wraps_ndarray_output():
+    """End-to-end: raw ndarray on `state["data"][nahual_embed_*]` must
+    produce a non-empty profiles table without raising."""
+    embedding = np.arange(8, dtype=np.float32).reshape(2, 4)
+    state = {"data": {"nahual_embed_cells": [embedding]}}
+    pipeline = {"steps": {"nahual_embed_cells": {}}}
+
+    profiles = get_profiles_from_state(state, pipeline)
+
+    assert isinstance(profiles, pa.Table)
+    assert profiles.num_rows > 0
+    assert "metadata_object" in profiles.column_names
+    assert "metadata_tp" in profiles.column_names
+    # One row per ndarray row, all under tp=0 and object=cells.
+    assert set(profiles.column("metadata_object").to_pylist()) == {"cells"}
+    assert set(profiles.column("metadata_tp").to_pylist()) == {0}
+
+
+def test_get_profiles_from_state_handles_multiple_timepoints():
+    """Each timepoint produces its own table; metadata_tp is set correctly."""
+    state = {
+        "data": {
+            "nahual_embed_cells": [
+                np.arange(6, dtype=np.float32).reshape(2, 3),
+                np.arange(6, dtype=np.float32).reshape(2, 3) + 100,
+            ]
+        }
+    }
+    pipeline = {"steps": {"nahual_embed_cells": {}}}
+
+    profiles = get_profiles_from_state(state, pipeline)
+
+    assert profiles.num_rows > 0
+    assert set(profiles.column("metadata_tp").to_pylist()) == {0, 1}


### PR DESCRIPTION
## Summary

Builds on @jfredinh's PR #20 (`fix-strict-zip`, commit `c0059c6`) with three additions, each in its own commit so they can be cherry-picked independently:

1. **Regression test** for the `nahual_embed_*` ndarray pathway. The DL-embedder terminal pathway in `get_profiles_from_state` had zero direct coverage (`grep`-verified). Four cases pin the fix from both sides: the buggy `cycle(...)` wrapper shape is pinned as a failure mode, and the fixed length-1 / length-1 shape is pinned as success — both single- and multi-timepoint.

2. **Notebook-style examples for publication** under `examples/`. Three scripts derived from the four downstream apps that consume aliby in production:
   - `01_cell_painting_tiff.py` — TIFF dir → cellpose → cp_measure (uoe-kenneth-amiodarone + the internal GSK pipeline it mirrors).
   - `02_zarr_deep_embeddings.py` — monozarr → `nahual_embed_*` via Nahual IPC (JUMP_lite/main). **This is the example that exercises the PR #20 fix.** Stubs an embedding ndarray through `get_profiles_from_state` when no live Nahual server is configured, so the fix is demonstrated end-to-end without needing a remote model.
   - `03_yeast_timelapse_baby.py` — TCZYX zarr → `nahual_baby` via baby-phone (aliby_baby_processing), including the `.zgroup` wrapper helper.

   Plus `src/aliby/test_data.py` — a shared pooch wrapper around the existing Zenodo deposit (record `19411429`) that exposes a `DATASETS` catalogue, `get_data_root`, `get_dataset`, `get_dataset_path`. Tests, examples, and (in a follow-up) the marimo notebooks all hit a single source of truth for the dataset URL / hash / cache layout. `tests/conftest.py`'s `data_dir` fixture is the first consumer.

   `examples/README.md` carries the catalogue, the bundled-fixture table, and a downstream cross-check checklist (four consumer apps + the aliby symbols each imports).

3. **CI extension** — `~/.cache/pooch` is now cached across CI runs keyed on the Zenodo tarball's known hash, and each example script is smoke-tested as `__main__` after pytest so drift in the script's top-to-bottom flow shows up in CI.

## Downstream consumer notes (worth a separate look)

While cross-checking I found that JUMP_lite/main still calls `run_pipeline_and_post(img_source=..., fov=...)` but current aliby's signature is `(pipeline, pipeline_name, output_path, overwrite)`. PR #20's fix unblocks the strict-zip failure but JUMP_lite needs a downstream-side update beyond PR #20 to actually run against current main. Documented in `examples/README.md`. The other three apps (uoe-kenneth, gsk-ia inferred, aliby_baby_processing) are unaffected by either issue.

## Test plan

- [x] `uv run pytest tests/` — 2245 passed, 7 skipped (data-gated), locally with VIRTUAL_ENV unset (see note below).
- [x] `uv run python examples/01_cell_painting_tiff.py` — runs end-to-end against bundled fixture, output matches inline "Expected:" comments.
- [x] `uv run python examples/02_zarr_deep_embeddings.py` — runs end-to-end, stubs embedder, demonstrates PR #20 fix.
- [x] `uv run python examples/03_yeast_timelapse_baby.py` — builds pipeline, stops before live BABY call (server-gated).
- [x] `grep -rE '(ELN[0-9]+|H00[A-Z0-9_]+|/datastore/alan/)' examples/*.py` returns nothing.
- [x] `python -m py_compile examples/*.py` clean.
- [ ] Watch CI for the matrix run (Linux + Mac × Python 3.11/3.12/3.13) plus the new smoke-test step.

## Note for local development

`uv run pytest tests/` can silently load `src/` from the wrong checkout if the parent shell exports `VIRTUAL_ENV` pointing at a different aliby venv. Prefix with `unset VIRTUAL_ENV;` or use `uv run --active` after activating the worktree's own venv. CI is unaffected (clean env).

🤖 Generated with [Claude Code](https://claude.com/claude-code)