### PR TITLE
fix(pipe): widen metadata_tp dtype to uint16 to support >255 time points

### DIFF
--- a/src/aliby/pipe_core.py
+++ b/src/aliby/pipe_core.py
@@ -492,7 +492,7 @@ def get_profiles_from_state(state: dict, pipeline: dict) -> pyarrow.Table:
                 )
                 table = table.append_column(
                     "metadata_tp",
-                    pyarrow.array([tp] * len(table), pyarrow.uint8()),
+                    pyarrow.array([tp] * len(table), pyarrow.uint16()),
                 )
                 data[step_prefix].append(table)
 


### PR DESCRIPTION
## Summary

- Widen `metadata_tp` column dtype in `get_profiles_from_state` from `pyarrow.uint8()` to `pyarrow.uint16()` (`pipe_core.py:495`).
- Fixes `pyarrow.lib.ArrowInvalid: Value 256 too large to fit in C integer type` on any extraction where `tp >= 256`.
- Resubmits the change from closed PR #17 — the prior PR was self-closed pending local validation that hadn't happened yet.

## Why

Yeast time-lapses in the Swain-lab corpus run to 270 timepoints; the active `aliby_baby_processing` run is currently failing on every site with >255 tps (most of the `ura7_*`, `ura8_*`, `phluorin_msn2_*`, `phluorin_mig1_*` series — ~36 sites in a prior batch). uint16's range (0–65 535) is comfortably enough for any realistic time-lapse and keeps the on-disk column narrow.

Note: the empty-table schema at `pipe_core.py:461` declares `metadata_tp` as `int64`, so this commit doesn't fully resolve the schema/array dtype mismatch — but that mismatch is pre-existing and the empty schema is discarded once any feature step produces rows. Out of scope for this PR.

## Test plan

- [x] Repro confirmed: `uv run python repros/uint8_timepoint_overflow.py` (in aliby_baby_processing) — fails on uint8, passes on uint16.
- [ ] Full pytest suite — PR #17 ran `nix develop --command pytest tests/ -q` against the same one-line change and reported 2238 passed, 7 skipped; rerun before merging.
- [ ] End-to-end validation on a >255-tp site once the in-flight `--ntps 1000` run finishes and we rerun the errored sites with this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)